### PR TITLE
Support bugsnag metadata

### DIFF
--- a/lib/my_api_client/errors.rb
+++ b/lib/my_api_client/errors.rb
@@ -4,6 +4,7 @@ module MyApiClient
   # The ancestor class for all API request error
   class Error < StandardError
     attr_reader :params
+    delegate :to_bugsnag, to: :params
 
     # Description of #initialize
     #

--- a/lib/my_api_client/params/params.rb
+++ b/lib/my_api_client/params/params.rb
@@ -15,11 +15,54 @@ module MyApiClient
         @response = response
       end
 
+      # Generate metadata for bugsnag.
+      # It will integrate request and response params.
+      # Blank parameter will be omitted.
+      #
+      # @return [Hash] Metadata for bugsnag
+      def to_bugsnag
+        request_metadata.merge(response_metadata)
+      end
+
       # Returns contents as string for to be readable for human
       #
       # @return [String] Contents as string
       def inspect
         { request: request, response: response }.inspect
+      end
+
+      private
+
+      # Generate metadata from request params.
+      # It will be added prefix "request_".
+      #
+      # @return [Hash] Metadata for bugsnag
+      def request_metadata
+        if request.present?
+          request.to_bugsnag.each_with_object({}) do |(key, value), memo|
+            memo[:"request_#{key}"] = value
+          end
+        else
+          {}
+        end
+      end
+
+      # Generate metadata from response params.
+      # It will be added prefix "response_".
+      #
+      # @return [Hash] Metadata for bugsnag
+      def response_metadata
+        if response.present?
+          data = response.data
+          body = data.respond_to?(:to_h) ? data.to_h : data
+          {
+            response_status: response.status,
+            response_headers: response.headers,
+            response_body: body,
+          }.compact
+        else
+          {}
+        end
       end
     end
   end

--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -6,6 +6,13 @@ module MyApiClient
     class Request
       attr_reader :method, :pathname, :headers, :query, :body
 
+      # Description of #initialize
+      #
+      # @param method [Symbol] describe_method_here
+      # @param pathname [String] describe_pathname_here
+      # @param headers [Hash, nil] describe_headers_here
+      # @param query [Hash, nil] describe_query_here
+      # @param body [Hash, nil] describe_body_here
       def initialize(method, pathname, headers, query, body)
         @method = method
         @pathname = pathname

--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -21,6 +21,9 @@ module MyApiClient
         @body = body
       end
 
+      # Description of #to_sawyer_args
+      #
+      # @return [Array<Object>] Arguments for Sawyer::Agent#call
       def to_sawyer_args
         [method, pathname, body, { headers: headers, query: query }]
       end

--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -25,6 +25,19 @@ module MyApiClient
         [method, pathname, body, { headers: headers, query: query }]
       end
 
+      # Generate metadata for bugsnag.
+      # Blank parameter will be omitted.
+      #
+      # @return [Hash] Metadata for bugsnag
+      def to_bugsnag
+        {
+          line: "#{method.upcase} #{pathname}",
+          headers: headers,
+          query: query,
+          body: body,
+        }.compact
+      end
+
       # Returns contents as string for to be readable for human
       #
       # @return [String] Contents as string

--- a/spec/lib/my_api_client/errors/error_spec.rb
+++ b/spec/lib/my_api_client/errors/error_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe MyApiClient::Error do
     end
   end
 
+  describe '#to_bugsnag' do
+    it 'delegates processing to params#to_bugsnag' do
+      allow(params).to receive(:to_bugsnag)
+      instance.to_bugsnag
+      expect(params).to have_received(:to_bugsnag)
+    end
+  end
+
   describe '#inspect' do
     it 'returns contents as string for to be readable for human' do
       expect(instance.inspect)

--- a/spec/lib/my_api_client/params/params_spec.rb
+++ b/spec/lib/my_api_client/params/params_spec.rb
@@ -3,20 +3,41 @@
 RSpec.describe MyApiClient::Params::Params do
   let(:instance) { described_class.new(request, response) }
 
-  describe '#inspect' do
-    let(:request) do
-      instance_double(
-        MyApiClient::Params::Request,
-        inspect: '"#<MyApiClient::Params::Request#inspect>"'
-      )
-    end
-    let(:response) do
-      instance_double(
-        Sawyer::Response,
-        inspect: '"#<Sawyer::Response#inspect>"'
-      )
-    end
+  let(:request) do
+    instance_double(
+      MyApiClient::Params::Request,
+      inspect: '"#<MyApiClient::Params::Request#inspect>"',
+      to_bugsnag: {
+        line: 'GET path/to/resource',
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        query: { key: 'value' },
+      }
+    )
+  end
+  let(:response) do
+    instance_double(
+      Sawyer::Response,
+      inspect: '"#<Sawyer::Response#inspect>"',
+      status: 200,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      data: { status: 'OK' }
+    )
+  end
 
+  describe '#to_bugsnag' do
+    it 'returns metadata which integrated request and response params' do
+      expect(instance.to_bugsnag).to eq(
+        request_line: 'GET path/to/resource',
+        request_headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        request_query: { key: 'value' },
+        response_status: 200,
+        response_headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        response_body: { status: 'OK' }
+      )
+    end
+  end
+
+  describe '#inspect' do
     it 'returns contents as string for to be readable for human' do
       expect(instance.inspect)
         .to eq '{:request=>"#<MyApiClient::Params::Request#inspect>", ' \

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe MyApiClient::Params::Request do
   let(:instance) { described_class.new(method, pathname, headers, query, body) }
-  let(:method) { 'GET' }
+  let(:method) { :get }
   let(:pathname) { 'path/to/resource' }
   let(:headers) { { 'Content-Type': 'application/json; charset=utf-8' } }
   let(:query) { { key: 'value' } }
@@ -11,7 +11,7 @@ RSpec.describe MyApiClient::Params::Request do
   describe '#to_sawyer_args' do
     it 'returns value formatted for arguments of Sawyer::Agent#call' do
       expect(instance.to_sawyer_args).to eq [
-        'GET',
+        :get,
         'path/to/resource',
         nil,
         {
@@ -25,7 +25,7 @@ RSpec.describe MyApiClient::Params::Request do
   describe '#inspect' do
     it 'returns contents as string for to be readable for human' do
       expect(instance.inspect)
-        .to eq '{:method=>"GET", ' \
+        .to eq '{:method=>:get, ' \
                ':pathname=>"path/to/resource", ' \
                ':headers=>{:"Content-Type"=>"application/json; charset=utf-8"}, ' \
                ':query=>{:key=>"value"}, :body=>nil}'

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe MyApiClient::Params::Request do
   let(:body) { nil }
 
   describe '#to_sawyer_args' do
-    subject { instance.to_sawyer_args }
-
     it 'returns value formatted for arguments of Sawyer::Agent#call' do
       expect(instance.to_sawyer_args).to eq [
         'GET',

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -22,6 +22,31 @@ RSpec.describe MyApiClient::Params::Request do
     end
   end
 
+  describe '#to_bugsnag' do
+    context 'when body parameter is blank' do
+      it 'returns hashed parameters which omitted body parameter' do
+        expect(instance.to_bugsnag).to eq(
+          line: 'GET path/to/resource',
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          query: { key: 'value' }
+        )
+      end
+    end
+
+    context 'when query parameter is blank' do
+      let(:body) { { username: 'John Smith' } }
+      let(:query) { nil }
+
+      it 'returns hashed parameters which omitted query parameter' do
+        expect(instance.to_bugsnag).to eq(
+          line: 'GET path/to/resource',
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          body: { username: 'John Smith' }
+        )
+      end
+    end
+  end
+
   describe '#inspect' do
     it 'returns contents as string for to be readable for human' do
       expect(instance.inspect)


### PR DESCRIPTION
Added #to_bugsnag method to `MyApiClient::Params::Params`. 
It makes easier to send metadata to bugsnag.

```rb
begin
  api_client = SomeApiClient.new.request
rescue MyApiClient::Error => e
  Bugsnag.notify(e, e.to_bugsnag)
end
```

I want to support Bugsnag::Breadcrumbs in the future.
See: https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.11.0