### PR TITLE
Add requirements for `$ bin/console`

### DIFF
--- a/lib/my_api_client.rb
+++ b/lib/my_api_client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'openssl'
+require 'net/http'
 require 'logger'
 require 'jsonpath'
 require 'active_support'


### PR DESCRIPTION
I could not execute `$ bin/console` because some requirements were missed.