### PR TITLE
Support bugsnag breadcrumb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ references:
       type: enum
       enum: ['4.2', '5.0', '5.1', '5.2']
       default: '4.2'
+  - &bundler_options
+    bundler_options:
+      type: string
+      default: ''
 
 executors:
   default:
@@ -36,6 +40,7 @@ commands:
     description: Setup Bundle
     parameters:
       <<: *ruby_version
+      <<: *bundler_options
     steps:
       - restore_cache:
           keys:
@@ -44,7 +49,7 @@ commands:
       - run:
           name: Bundle Install
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --jobs=4 --retry=3 --path vendor/bundle << parameters.bundler_options >>
       - save_cache:
           paths:
             - ./vendor/bundle
@@ -124,11 +129,13 @@ commands:
     parameters:
       <<: *ruby_version
       <<: *rails_version
+      <<: *bundler_options
     steps:
       - checkout
       - download_cc_test_reporter
       - setup_bundle:
           ruby_version: << parameters.ruby_version >>
+          bundler_options: << parameters.bundler_options >>
       - modify_active_support_version:
           rails_version: << parameters.rails_version >>
       - run_rspec
@@ -139,6 +146,7 @@ jobs:
     parameters:
       <<: *ruby_version
       <<: *rails_version
+      <<: *bundler_options
     executor:
       name: default
       ruby_version: << parameters.ruby_version >>
@@ -146,6 +154,7 @@ jobs:
       - build:
           ruby_version: << parameters.ruby_version >>
           rails_version: << parameters.rails_version >>
+          bundler_options: << parameters.bundler_options >>
   rubocop:
     executor:
       name: default
@@ -220,9 +229,15 @@ workflows:
           ruby_version:  '2.6'
           rails_version: '5.1'
       - build:
-          name: build_on_ruby_2_6_and_rails_5_2
+          name: build_on_ruby_2_6_and_rails_5_2_with_integrations
           ruby_version:  '2.6'
           rails_version: '5.2'
+          bundler_options: '--with integrations'
+      - build:
+          name: build_on_ruby_2_6_and_rails_5_2_without_integrations
+          ruby_version:  '2.6'
+          rails_version: '5.2'
+          bundler_options: '--without integrations'
       - rubocop
       - yardoc
       - release:
@@ -239,7 +254,8 @@ workflows:
             - build_on_ruby_2_6_and_rails_4_2
             - build_on_ruby_2_6_and_rails_5_0
             - build_on_ruby_2_6_and_rails_5_1
-            - build_on_ruby_2_6_and_rails_5_2
+            - build_on_ruby_2_6_and_rails_5_2_with_integrations
+            - build_on_ruby_2_6_and_rails_5_2_without_integrations
             - rubocop
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,23 +121,22 @@ commands:
             bundle exec rake release --trace
   setup:
     description: Setup for Job Working
-    steps:
-      - checkout
-      - setup_bundle
-  build:
-    description: Build the RubyGem
     parameters:
       <<: *ruby_version
-      <<: *rails_version
       <<: *bundler_options
     steps:
       - checkout
-      - download_cc_test_reporter
       - setup_bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_options: << parameters.bundler_options >>
+  test_and_build:
+    description: Build the RubyGem
+    parameters:
+      <<: *rails_version
+    steps:
       - modify_active_support_version:
           rails_version: << parameters.rails_version >>
+      - download_cc_test_reporter
       - run_rspec
       - rake_build
 
@@ -151,10 +150,11 @@ jobs:
       name: default
       ruby_version: << parameters.ruby_version >>
     steps:
-      - build:
+      - setup:
           ruby_version: << parameters.ruby_version >>
-          rails_version: << parameters.rails_version >>
           bundler_options: << parameters.bundler_options >>
+      - test_and_build:
+          rails_version: << parameters.rails_version >>
   rubocop:
     executor:
       name: default

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,7 @@ RSpec/ExampleLength:
 
 RSpec/FilePath:
   Exclude:
+    - 'spec/lib/my_api_client/integrations/**/*'
     - 'spec/lib/my_api_client/errors/**/*'
     - 'spec/lib/my_api_client/rspec/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+group :integrations, optional: true do
+  gem 'bugsnag', '>= 6.11.0'
+end
+
 # Specify your gem's dependencies in my_api_client.gemspec
 gemspec
-
-gem 'bugsnag', '>= 6.11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in my_api_client.gemspec
 gemspec
 
-gem 'bugsnag', '~> 6.11.0'
+gem 'bugsnag', '>= 6.11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in my_api_client.gemspec
 gemspec
+
+gem 'bugsnag', '~> 6.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bugsnag (~> 6.11.0)
+  bugsnag (>= 6.11.0)
   bundler (~> 1.16)
   my_api_client!
   pr_comet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    bugsnag (6.11.1)
+      concurrent-ruby (~> 1.0)
     byebug (11.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -105,6 +107,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bugsnag (~> 6.11.0)
   bundler (~> 1.16)
   my_api_client!
   pr_comet

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -8,4 +8,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', '~> 4.2.0'
 
+group :integrations, optional: true do
+  gem 'bugsnag', '>= 6.11.0'
+end
+
 gemspec

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -8,4 +8,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', '~> 5.0.0'
 
+group :integrations, optional: true do
+  gem 'bugsnag', '>= 6.11.0'
+end
+
 gemspec

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -8,4 +8,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', '~> 5.1.0'
 
+group :integrations, optional: true do
+  gem 'bugsnag', '>= 6.11.0'
+end
+
 gemspec

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -8,4 +8,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', '~> 5.2.0'
 
+group :integrations, optional: true do
+  gem 'bugsnag', '>= 6.11.0'
+end
+
 gemspec

--- a/lib/my_api_client.rb
+++ b/lib/my_api_client.rb
@@ -17,6 +17,7 @@ require 'my_api_client/params/params'
 require 'my_api_client/params/request'
 require 'my_api_client/request'
 require 'my_api_client/base'
+require 'my_api_client/integrations/bugsnag'
 
 if Sawyer::VERSION < '0.8.2'
   module Sawyer

--- a/lib/my_api_client.rb
+++ b/lib/my_api_client.rb
@@ -17,7 +17,7 @@ require 'my_api_client/params/params'
 require 'my_api_client/params/request'
 require 'my_api_client/request'
 require 'my_api_client/base'
-require 'my_api_client/integrations/bugsnag'
+require 'my_api_client/integrations/bugsnag' if defined?(Bugsnag) && Bugsnag::VERSION >= '6.11.0'
 
 if Sawyer::VERSION < '0.8.2'
   module Sawyer

--- a/lib/my_api_client.rb
+++ b/lib/my_api_client.rb
@@ -17,7 +17,14 @@ require 'my_api_client/params/params'
 require 'my_api_client/params/request'
 require 'my_api_client/request'
 require 'my_api_client/base'
-require 'my_api_client/integrations/bugsnag' if defined?(Bugsnag) && Bugsnag::VERSION >= '6.11.0'
+
+# Loads gems for feature of integrations
+begin
+  require 'bugsnag'
+  require 'my_api_client/integrations/bugsnag' if defined?(Bugsnag) && Bugsnag::VERSION >= '6.11.0'
+rescue LoadError
+  nil
+end
 
 if Sawyer::VERSION < '0.8.2'
   module Sawyer

--- a/lib/my_api_client/errors.rb
+++ b/lib/my_api_client/errors.rb
@@ -7,10 +7,12 @@ module MyApiClient
     delegate :metadata, to: :params
     alias to_bugsnag metadata
 
-    # Description of #initialize
+    # Initialize the error class
     #
-    # @param params [MyApiClient::Params::Params] describe_params_here
-    # @param error_message [String] default: nil
+    # @param params [MyApiClient::Params::Params]
+    #   The request and response parameters
+    # @param error_message [String]
+    #   The error description
     def initialize(params, error_message = nil)
       @params = params
       super error_message
@@ -36,10 +38,12 @@ module MyApiClient
   class NetworkError < Error
     attr_reader :original_error
 
-    # Description of #initialize
+    # Initialize the error class
     #
-    # @param params [MyApiClient::Params::Params] describe_params_here
-    # @param original_error [StandardError] Some network error
+    # @param params [MyApiClient::Params::Params]
+    #   The request and response parameters
+    # @param original_error [StandardError]
+    #   Some network error
     def initialize(params, original_error)
       @original_error = original_error
       super params, original_error.message
@@ -50,6 +54,13 @@ module MyApiClient
     # @return [String] Contents as string
     def inspect
       { error: original_error, params: params }.inspect
+    end
+
+    # Generate metadata for bugsnag.
+    #
+    # @return [Hash] Metadata for bugsnag
+    def metadata
+      super.merge(original_error: original_error.inspect)
     end
   end
 

--- a/lib/my_api_client/errors.rb
+++ b/lib/my_api_client/errors.rb
@@ -4,7 +4,8 @@ module MyApiClient
   # The ancestor class for all API request error
   class Error < StandardError
     attr_reader :params
-    delegate :to_bugsnag, to: :params
+    delegate :metadata, to: :params
+    alias to_bugsnag metadata
 
     # Description of #initialize
     #

--- a/lib/my_api_client/integrations/bugsnag.rb
+++ b/lib/my_api_client/integrations/bugsnag.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+if defined? Bugsnag && Bugsnag::VERSION >= '6.11.0'
+  require 'bugsnag'
+  module MyApiClient
+    # Override lib/my_api_client/errors.rb for supporting Bugsnag breadcrumbs
+    class Error < StandardError
+      alias _original_initialize initialize
+
+      # Override MyApiClient::Error#initialize
+      def initialize(params, error_message = nil)
+        _original_initialize(params, error_message)
+
+        Bugsnag.leave_breadcrumb(
+          "#{self.class.name} occurred",
+          metadata,
+          Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
+        )
+      end
+    end
+  end
+end

--- a/lib/my_api_client/integrations/bugsnag.rb
+++ b/lib/my_api_client/integrations/bugsnag.rb
@@ -1,22 +1,19 @@
 # frozen_string_literal: true
 
-if defined? Bugsnag && Bugsnag::VERSION >= '6.11.0'
-  require 'bugsnag'
-  module MyApiClient
-    # Override lib/my_api_client/errors.rb for supporting Bugsnag breadcrumbs
-    class Error < StandardError
-      alias _original_initialize initialize
+module MyApiClient
+  # Override lib/my_api_client/errors.rb for supporting Bugsnag breadcrumbs
+  class Error < StandardError
+    alias _original_initialize initialize
 
-      # Override MyApiClient::Error#initialize
-      def initialize(params, error_message = nil)
-        _original_initialize(params, error_message)
+    # Override MyApiClient::Error#initialize
+    def initialize(params, error_message = nil)
+      _original_initialize(params, error_message)
 
-        Bugsnag.leave_breadcrumb(
-          "#{self.class.name} occurred",
-          metadata,
-          Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
-        )
-      end
+      Bugsnag.leave_breadcrumb(
+        "#{self.class.name} occurred",
+        metadata,
+        Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
+      )
     end
   end
 end

--- a/lib/my_api_client/params/params.rb
+++ b/lib/my_api_client/params/params.rb
@@ -20,9 +20,10 @@ module MyApiClient
       # Blank parameter will be omitted.
       #
       # @return [Hash] Metadata for bugsnag
-      def to_bugsnag
+      def metadata
         request_metadata.merge(response_metadata)
       end
+      alias to_bugsnag metadata
 
       # Returns contents as string for to be readable for human
       #
@@ -39,7 +40,7 @@ module MyApiClient
       # @return [Hash] Metadata for bugsnag
       def request_metadata
         if request.present?
-          request.to_bugsnag.each_with_object({}) do |(key, value), memo|
+          request.metadata.each_with_object({}) do |(key, value), memo|
             memo[:"request_#{key}"] = value
           end
         else

--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -32,7 +32,7 @@ module MyApiClient
       # Blank parameter will be omitted.
       #
       # @return [Hash] Metadata for bugsnag
-      def to_bugsnag
+      def metadata
         {
           line: "#{method.upcase} #{pathname}",
           headers: headers,
@@ -40,6 +40,7 @@ module MyApiClient
           body: body,
         }.compact
       end
+      alias to_bugsnag metadata
 
       # Returns contents as string for to be readable for human
       #

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -46,7 +46,7 @@ module MyApiClient
     def process_raise_option(exception)
       case exception
       when Class
-        params = instance_double(MyApiClient::Params::Params, to_bugsnag: {})
+        params = instance_double(MyApiClient::Params::Params, metadata: {})
         if exception == MyApiClient::NetworkError
           exception.new(params, Net::OpenTimeout.new)
         else

--- a/spec/lib/my_api_client/error_handling_spec.rb
+++ b/spec/lib/my_api_client/error_handling_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe MyApiClient::ErrorHandling do
         Sawyer::Response, status: status_code, body: response_body.to_json
       )
     end
-    let(:params) { instance_double(MyApiClient::Params::Params) }
+    let(:params) { instance_double(MyApiClient::Params::Params, metadata: {}) }
     let(:logger) { instance_double(MyApiClient::Logger) }
 
     describe 'use `status_code`' do

--- a/spec/lib/my_api_client/errors/error_spec.rb
+++ b/spec/lib/my_api_client/errors/error_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe MyApiClient::Error do
     end
   end
 
-  describe '#to_bugsnag' do
-    it 'delegates processing to params#to_bugsnag' do
-      allow(params).to receive(:to_bugsnag)
-      instance.to_bugsnag
-      expect(params).to have_received(:to_bugsnag)
+  describe '#metadata' do
+    it 'delegates processing to params#metadata' do
+      allow(params).to receive(:metadata)
+      instance.metadata
+      expect(params).to have_received(:metadata)
     end
   end
 

--- a/spec/lib/my_api_client/errors/error_spec.rb
+++ b/spec/lib/my_api_client/errors/error_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe MyApiClient::Error do
   let(:instance) { described_class.new(params) }
   let(:params) do
     instance_double(
-      MyApiClient::Params::Params, inspect: '"#<MyApiClient::Params::Params#inspect>"'
+      MyApiClient::Params::Params,
+      inspect: '"#<MyApiClient::Params::Params#inspect>"',
+      metadata: {}
     )
   end
 
@@ -16,9 +18,8 @@ RSpec.describe MyApiClient::Error do
 
   describe '#metadata' do
     it 'delegates processing to params#metadata' do
-      allow(params).to receive(:metadata)
       instance.metadata
-      expect(params).to have_received(:metadata)
+      expect(params).to have_received(:metadata).twice
     end
   end
 

--- a/spec/lib/my_api_client/errors/error_spec.rb
+++ b/spec/lib/my_api_client/errors/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MyApiClient::Error do
     instance_double(
       MyApiClient::Params::Params,
       inspect: '"#<MyApiClient::Params::Params#inspect>"',
-      metadata: {}
+      metadata: { request: 'params', response: 'params' }
     )
   end
 
@@ -18,8 +18,7 @@ RSpec.describe MyApiClient::Error do
 
   describe '#metadata' do
     it 'delegates processing to params#metadata' do
-      instance.metadata
-      expect(params).to have_received(:metadata).twice
+      expect(instance.metadata).to eq(request: 'params', response: 'params')
     end
   end
 

--- a/spec/lib/my_api_client/errors/network_error_spec.rb
+++ b/spec/lib/my_api_client/errors/network_error_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe MyApiClient::NetworkError do
   let(:instance) { described_class.new(params, network_error) }
   let(:params) do
     instance_double(
-      MyApiClient::Params::Params, inspect: '"#<MyApiClient::Params::Params#inspect>"'
+      MyApiClient::Params::Params,
+      inspect: '"#<MyApiClient::Params::Params#inspect>"',
+      metadata: { params: 'original metadata' }
     )
   end
   let(:network_error) do
@@ -30,6 +32,13 @@ RSpec.describe MyApiClient::NetworkError do
       expect(instance.inspect)
         .to eq '{:error=>"#<Net::OpenTimeout>", ' \
                ':params=>"#<MyApiClient::Params::Params#inspect>"}'
+    end
+  end
+
+  describe '#metadata' do
+    it 'overrides super class #metadata to add original error information' do
+      expect(instance.metadata)
+        .to eq(params: 'original metadata', original_error: network_error.inspect)
     end
   end
 end

--- a/spec/lib/my_api_client/integrations/bugsnag_spec.rb
+++ b/spec/lib/my_api_client/integrations/bugsnag_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe MyApiClient::Error do
+  describe '#initialize' do
+    let(:params) { instance_double(MyApiClient::Params::Params, metadata: metadata) }
+    let(:metadata) { { metadata: 'metadata' } }
+
+    it 'calls Bugsnag.leave_breadcrumb with #metadata' do
+      allow(Bugsnag).to receive(:leave_breadcrumb)
+      described_class.new(params, 'error message')
+      expect(Bugsnag).to have_received(:leave_breadcrumb).with(
+        'MyApiClient::Error occurred',
+        metadata,
+        Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
+      )
+    end
+  end
+end

--- a/spec/lib/my_api_client/integrations/bugsnag_spec.rb
+++ b/spec/lib/my_api_client/integrations/bugsnag_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.describe MyApiClient::Error do
-  describe '#initialize' do
-    let(:params) { instance_double(MyApiClient::Params::Params, metadata: metadata) }
-    let(:metadata) { { metadata: 'metadata' } }
+if defined?(Bugsnag)
+  RSpec.describe MyApiClient::Error do
+    describe '#initialize' do
+      let(:params) { instance_double(MyApiClient::Params::Params, metadata: metadata) }
+      let(:metadata) { { metadata: 'metadata' } }
 
-    it 'calls Bugsnag.leave_breadcrumb with #metadata' do
-      allow(Bugsnag).to receive(:leave_breadcrumb)
-      described_class.new(params, 'error message')
-      expect(Bugsnag).to have_received(:leave_breadcrumb).with(
-        'MyApiClient::Error occurred',
-        metadata,
-        Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
-      )
+      it 'calls Bugsnag.leave_breadcrumb with #metadata' do
+        allow(Bugsnag).to receive(:leave_breadcrumb)
+        described_class.new(params, 'error message')
+        expect(Bugsnag).to have_received(:leave_breadcrumb).with(
+          'MyApiClient::Error occurred',
+          metadata,
+          Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
+        )
+      end
     end
   end
 end

--- a/spec/lib/my_api_client/params/params_spec.rb
+++ b/spec/lib/my_api_client/params/params_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MyApiClient::Params::Params do
     instance_double(
       MyApiClient::Params::Request,
       inspect: '"#<MyApiClient::Params::Request#inspect>"',
-      to_bugsnag: {
+      metadata: {
         line: 'GET path/to/resource',
         headers: { 'Content-Type': 'application/json; charset=utf-8' },
         query: { key: 'value' },
@@ -24,10 +24,10 @@ RSpec.describe MyApiClient::Params::Params do
     )
   end
 
-  describe '#to_bugsnag' do
+  describe '#metadata' do
     context 'when given both params of request and response' do
       it 'returns metadata which integrated request and response params' do
-        expect(instance.to_bugsnag).to eq(
+        expect(instance.metadata).to eq(
           request_line: 'GET path/to/resource',
           request_headers: { 'Content-Type': 'application/json; charset=utf-8' },
           request_query: { key: 'value' },
@@ -42,7 +42,7 @@ RSpec.describe MyApiClient::Params::Params do
       let(:response) { nil }
 
       it 'returns metadata just including request params' do
-        expect(instance.to_bugsnag).to eq(
+        expect(instance.metadata).to eq(
           request_line: 'GET path/to/resource',
           request_headers: { 'Content-Type': 'application/json; charset=utf-8' },
           request_query: { key: 'value' }
@@ -54,7 +54,7 @@ RSpec.describe MyApiClient::Params::Params do
       let(:request) { nil }
 
       it 'returns metadata just including response params' do
-        expect(instance.to_bugsnag).to eq(
+        expect(instance.metadata).to eq(
           response_status: 200,
           response_headers: { 'Content-Type': 'application/json; charset=utf-8' },
           response_body: { status: 'OK' }

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe MyApiClient::Params::Request do
     end
   end
 
-  describe '#to_bugsnag' do
+  describe '#metadata' do
     context 'when body parameter is blank' do
       it 'returns hashed parameters which omitted body parameter' do
-        expect(instance.to_bugsnag).to eq(
+        expect(instance.metadata).to eq(
           line: 'GET path/to/resource',
           headers: { 'Content-Type': 'application/json; charset=utf-8' },
           query: { key: 'value' }
@@ -38,7 +38,7 @@ RSpec.describe MyApiClient::Params::Request do
       let(:query) { nil }
 
       it 'returns hashed parameters which omitted query parameter' do
-        expect(instance.to_bugsnag).to eq(
+        expect(instance.metadata).to eq(
           line: 'GET path/to/resource',
           headers: { 'Content-Type': 'application/json; charset=utf-8' },
           body: { username: 'John Smith' }

--- a/spec/lib/my_api_client/request_spec.rb
+++ b/spec/lib/my_api_client/request_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe MyApiClient::Request do
     let(:body) { nil }
     let(:response_body) { { message: 'OK' }.to_json }
     let(:agent) { instance_double(Sawyer::Agent, call: response) }
-    let(:response) { instance_double(Sawyer::Response, status: 200, data: resource, timing: 0.1) }
+    let(:response) do
+      instance_double(Sawyer::Response, status: 200, data: resource, timing: 0.1, headers: nil)
+    end
     let(:resource) { instance_double(Sawyer::Resource) }
     let(:logger) { instance_double(::Logger) }
     let(:request_logger) { instance_double(MyApiClient::Logger, info: nil, warn: nil, error: nil) }

--- a/spec/lib/my_api_client/rspec/stub_spec.rb
+++ b/spec/lib/my_api_client/rspec/stub_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe MyApiClient::Stub do
 
       context 'with MyApiClient::Error instance' do
         it 'stubs ApiClient as that raises Error set by `raise` on executes' do
-          params = instance_double(MyApiClient::Params::Params, to_bugsnag: {})
+          params = instance_double(MyApiClient::Params::Params, metadata: {})
           error = MyApiClient::ServerError.new(params)
           my_api_client_stub(self.class::ExampleApiClient, :request, raise: error)
           expect { api_request! }.to raise_error(MyApiClient::ServerError)


### PR DESCRIPTION
closes #23

> [Bugsnag-Ruby v6.11.0](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.11.0) was Added new feature whic called logging breadcrumbs.
> I want to support that feature in this gem.
> 
> See: https://docs.bugsnag.com/platforms/ruby/other/#logging-breadcrumbs
> 
> refs: #22