### PR TITLE
Fix unsupported data for the Bugsnag breadcrumbs

### DIFF
--- a/lib/my_api_client/integrations/bugsnag.rb
+++ b/lib/my_api_client/integrations/bugsnag.rb
@@ -11,7 +11,7 @@ module MyApiClient
 
       Bugsnag.leave_breadcrumb(
         "#{self.class.name} occurred",
-        metadata,
+        metadata.each_with_object({}) { |(k, v), memo| memo[k] = v.inspect },
         Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
       )
     end

--- a/spec/lib/my_api_client/integrations/bugsnag_spec.rb
+++ b/spec/lib/my_api_client/integrations/bugsnag_spec.rb
@@ -4,14 +4,14 @@ if defined?(Bugsnag)
   RSpec.describe MyApiClient::Error do
     describe '#initialize' do
       let(:params) { instance_double(MyApiClient::Params::Params, metadata: metadata) }
-      let(:metadata) { { metadata: 'metadata' } }
+      let(:metadata) { { a: 1, b: { c: 2, d: 3 } } }
 
       it 'calls Bugsnag.leave_breadcrumb with #metadata' do
         allow(Bugsnag).to receive(:leave_breadcrumb)
         described_class.new(params, 'error message')
         expect(Bugsnag).to have_received(:leave_breadcrumb).with(
           'MyApiClient::Error occurred',
-          metadata,
+          { a: '1', b: '{:c=>2, :d=>3}' },
           Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
         )
       end


### PR DESCRIPTION
## Why

The feature of Bugsnag breadcrumbs supports only following data.

> https://docs.bugsnag.com/platforms/ruby/rails/#logging-breadcrumbs
> The breadcrumb name will be trimmed to be 30 characters maximum, and all meta data must be of the **Numeric, String, TrueClass, or FalseClass types, or nil**.

But the `MyApiClient::Error#metadata` includes the Array, Hash and so on.

https://github.com/ryz310/my_api_client/blob/03182c9577e632ae5f30786efe0876de6ead00d1/lib/my_api_client/integrations/bugsnag.rb#L12-L16

So unfortunately, some metadata has excluded from breadcrumbs.

![スクリーンショット_2019-06-19_12_52_07](https://user-images.githubusercontent.com/3985540/59735609-2af31e00-9291-11e9-883a-f0a0de41b7e7.png)


## How

The workaround is to convert metadata into strings.