### PR TITLE
Initialize sawyer agent before logger initialization

### DIFF
--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -16,6 +16,7 @@ module MyApiClient
     def _request(http_method, pathname, headers, query, body, logger)
       processed_path = [common_path, pathname].join('/').gsub('//', '/')
       request_params = Params::Request.new(http_method, processed_path, headers, query, body)
+      agent # Initializes for faraday
       request_logger = Logger.new(logger, faraday, http_method, processed_path)
       call(:_execute, request_params, request_logger)
     end

--- a/spec/lib/my_api_client/request_spec.rb
+++ b/spec/lib/my_api_client/request_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe MyApiClient::Request do
         .with(nil, request: { timeout: 3.seconds, open_timeout: 2.seconds })
     end
 
+    it 'initializes in order of faraday, sawyer, logger' do
+      request!
+      expect(Faraday).to have_received(:new).ordered
+      expect(Sawyer::Agent).to have_received(:new).ordered
+      expect(MyApiClient::Logger).to have_received(:new).ordered
+    end
+
     it 'calls Sawyer::Agent#call with request parameters' do
       request!
       expect(agent)


### PR DESCRIPTION
fixes #53

> The log `GET http:/v3.3/me/friends` is wrong URL. It is not considering schema and domain name.
> 
> ```
> I, [2019-06-19T15:12:33.753081 #58]  INFO -- : API request `GET http:/v3.3/me/friends`: "Start"
> I, [2019-06-19T15:12:34.225469 #58]  INFO -- : API request `GET http:/v3.3/me/friends`: "Duration 0.4365701 sec"
> I, [2019-06-19T15:12:34.260660 #58]  INFO -- : API request `GET http:/v3.3/me/friends`: "Success (200)"
> ```
> 
> The reason is that the Faraday instance is initialized by Sawyer::Agent#initialize but it has not yet been called at timing of Logger instance initialization.
> 
> https://github.com/ryz310/my_api_client/blob/38c4130970fdf013326d1b46cc7b56602dadd809/lib/my_api_client/request.rb#L16-L21
