### PR TITLE
Ignore error handling when using request to matcher

### DIFF
--- a/lib/my_api_client/rspec/matchers/be_handled_as_an_error.rb
+++ b/lib/my_api_client/rspec/matchers/be_handled_as_an_error.rb
@@ -52,7 +52,7 @@ RSpec::Matchers.define :be_handled_as_an_error do |expected_error_class|
       headers: expected_response[:headers] || {},
       body: expected_response[:body] || nil
     )
-    @sawyer = instance_double(Sawyer::Agent, call: response, sleep: nil)
+    @sawyer = instance_double(Sawyer::Agent, call: response)
     allow(Sawyer::Agent).to receive(:new).and_return(sawyer)
   end
 

--- a/lib/my_api_client/rspec/matchers/request_to.rb
+++ b/lib/my_api_client/rspec/matchers/request_to.rb
@@ -27,7 +27,7 @@ RSpec::Matchers.define :request_to do |expected_method, expected_url|
           query: options[:query],
         }.compact
     end.and_return(dummy_response)
-    api_request.call
+    safe_execution(api_request)
     @expected == @actual
   end
 
@@ -42,6 +42,13 @@ RSpec::Matchers.define :request_to do |expected_method, expected_url|
       expected to request to "#{@expected[:request_line]}"
       Diff: #{diff_as_object(@actual, @expected)}
     MESSAGE
+  end
+
+  # To ignore error handling
+  def safe_execution(api_request)
+    api_request.call
+  rescue MyApiClient::Error
+    nil
   end
 
   def request_line(method, url)


### PR DESCRIPTION
For the `forbit_nil` option.