### PR TITLE
Fix `be_handled_as_an_error` description

### DIFF
--- a/lib/my_api_client/rspec/matchers/be_handled_as_an_error.rb
+++ b/lib/my_api_client/rspec/matchers/be_handled_as_an_error.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :be_handled_as_an_error do |expected_error_class|
   chain :when_receive, :expected_response
 
   description do
-    message = "be handled as #{expected_error_class}"
+    message = "be handled as #{expected_error_class || 'an error'}"
     message += " after retry #{retry_count} times" unless retry_count.nil?
     message
   end


### PR DESCRIPTION
Currently, calling `be_handled_as_an_error` matcher without an error class displays as following:

```
is expected not to be handled as
```

This PR fixes it, and then displays as following:

```
is expected not to be handled as an error
```