### PR TITLE
Redefine network error class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     my_api_client (0.10.2)
       activesupport (>= 4.2.0)
+      faraday (>= 0.17.1)
       jsonpath
       sawyer (>= 0.8.2)
 

--- a/lib/my_api_client/errors.rb
+++ b/lib/my_api_client/errors.rb
@@ -27,7 +27,9 @@ module MyApiClient
   end
 
   NETWORK_ERRORS = [
-    Faraday::ClientError,
+    Faraday::TimeoutError,
+    Faraday::ConnectionFailed,
+    Faraday::SSLError,
     OpenSSL::SSL::SSLError,
     Net::OpenTimeout,
     Net::ReadTimeout,

--- a/my_api_client.gemspec
+++ b/my_api_client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 4.2.0'
+  spec.add_dependency 'faraday', '>= 0.17.1'
   spec.add_dependency 'jsonpath'
   spec.add_dependency 'sawyer', '>= 0.8.2'
 


### PR DESCRIPTION
The faraday gem error class definitions were updated by [v0.17.1](https://github.com/lostisland/faraday/pull/1082) and then some error class' super classes were changed.

Originally, any network error classes had inherited `Faraday::ClientError` class, but currently have inherited `Faraday::ServerError` or `Faraday::Error` class.

The `my_api_client` gem needs redefine the network error class and to add dependency by the faraday gem version.