### PR TITLE
Fix warning on ruby 2.7

### DIFF
--- a/lib/my_api_client/error_handling.rb
+++ b/lib/my_api_client/error_handling.rb
@@ -42,7 +42,7 @@ module MyApiClient
         options[:block] = block if block_given?
 
         temp = error_handlers.dup
-        temp << ->(response) { Generator.call(options.merge(response: response)) }
+        temp << ->(response) { Generator.call(**options.merge(response: response)) }
         self.error_handlers = temp
       end
     end

--- a/lib/my_api_client/error_handling/generator.rb
+++ b/lib/my_api_client/error_handling/generator.rb
@@ -26,7 +26,7 @@ module MyApiClient
       # @return [Symbol]
       #   Returns value as `Symbol` if given `with` option
       def self.call(**options)
-        new(options).send(:call)
+        new(**options).send(:call)
       end
 
       private

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -23,7 +23,7 @@ module MyApiClient
     # @return [InstanceDouble]
     #   Returns a spy object of the stubbed ApiClient.
     def stub_api_client_all(klass, **actions_and_options)
-      instance = stub_api_client(klass, actions_and_options)
+      instance = stub_api_client(klass, **actions_and_options)
       allow(klass).to receive(:new).and_return(instance)
       instance
     end

--- a/lib/my_api_client/service_abstract.rb
+++ b/lib/my_api_client/service_abstract.rb
@@ -5,13 +5,13 @@ module MyApiClient
   class ServiceAbstract
     private_class_method :new
 
-    def self.call(*args, &block)
-      new(*args, &block).send(:call)
+    def self.call(**args, &block)
+      new(**args, &block).send(:call)
     end
 
     # private
 
-    # def initialize(*_args)
+    # def initialize(**_args)
     #   raise "You must implement #{self.class}##{__method__}"
     # end
 

--- a/my_api_client.gemspec
+++ b/my_api_client.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4.0'
+
   spec.add_dependency 'activesupport', '>= 4.2.0'
   spec.add_dependency 'faraday', '>= 0.17.1'
   spec.add_dependency 'jsonpath'


### PR DESCRIPTION
Fixed: `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`