### PR TITLE
Change the request structure

### DIFF
--- a/lib/my_api_client/base.rb
+++ b/lib/my_api_client/base.rb
@@ -21,23 +21,5 @@ module MyApiClient
     # NOTE: This class **MUST NOT** implement #initialize method. Because it
     #       will become constraint that need call #super in the #initialize at
     #       definition of the child classes.
-
-    HTTP_METHODS = %i[get post patch delete].freeze
-
-    HTTP_METHODS.each do |http_method|
-      class_eval <<~METHOD, __FILE__, __LINE__ + 1
-        # Description of ##{http_method}
-        #
-        # @param pathname [String]
-        # @param headers [Hash, nil]
-        # @param query [Hash, nil]
-        # @param body [Hash, nil]
-        # @return [Sawyer::Resouce] description_of_returned_object
-        def #{http_method}(pathname, headers: nil, query: nil, body: nil)
-          _request :#{http_method}, pathname, headers, query, body, logger
-        end
-      METHOD
-    end
-    alias put patch
   end
 end

--- a/lib/my_api_client/config.rb
+++ b/lib/my_api_client/config.rb
@@ -16,34 +16,5 @@ module MyApiClient
         METHOD
       end
     end
-
-    # Extracts schema and hostname from endpoint
-    #
-    # @example Extracts schema and hostname from 'https://example.com/path/to/api'
-    #   schema_and_hostname # => 'https://example.com'
-    # @return [String] description_of_returned_object
-    def schema_and_hostname
-      if _uri.default_port == _uri.port
-        "#{_uri.scheme}://#{_uri.host}"
-      else
-        "#{_uri.scheme}://#{_uri.host}:#{_uri.port}"
-      end
-    end
-
-    # Extracts pathname from endpoint
-    #
-    # @example Extracts pathname from 'https://example.com/path/to/api'
-    #   common_path # => 'path/to/api'
-    # @return [String] The pathanem
-    def common_path
-      _uri.path
-    end
-
-    private
-
-    # @return [URI] Returns a memoized URI instance
-    def _uri
-      @_uri ||= URI.parse(endpoint)
-    end
   end
 end

--- a/lib/my_api_client/logger.rb
+++ b/lib/my_api_client/logger.rb
@@ -3,20 +3,19 @@
 module MyApiClient
   # Description of Logger
   class Logger
-    attr_reader :logger, :method, :pathname
+    attr_reader :logger, :method, :uri
 
     LOG_LEVEL = %i[debug info warn error fatal].freeze
 
     # Description of #initialize
     #
     # @param logger [::Logger] describe_logger_here
-    # @param faraday [Faraday::Connection] describe_faraday_here
     # @param method [String] HTTP method
-    # @param pathname [String] The path name
-    def initialize(logger, faraday, method, pathname)
+    # @param uri [URI] Target URI
+    def initialize(logger, method, uri)
       @logger = logger
       @method = method.to_s.upcase
-      @pathname = faraday.build_exclusive_url(pathname)
+      @uri = uri
     end
 
     LOG_LEVEL.each do |level|
@@ -30,7 +29,7 @@ module MyApiClient
     private
 
     def format(message)
-      "API request `#{method} #{pathname}`: \"#{message}\""
+      "API request `#{method} #{uri}`: \"#{message}\""
     end
   end
 end

--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -4,20 +4,18 @@ module MyApiClient
   module Params
     # Description of Params
     class Request
-      attr_reader :method, :pathname, :headers, :query, :body
+      attr_reader :method, :uri, :headers, :body
 
       # Description of #initialize
       #
       # @param method [Symbol] describe_method_here
-      # @param pathname [String] describe_pathname_here
+      # @param uri [URI] describe_uri_here
       # @param headers [Hash, nil] describe_headers_here
-      # @param query [Hash, nil] describe_query_here
       # @param body [Hash, nil] describe_body_here
-      def initialize(method, pathname, headers, query, body)
+      def initialize(method, uri, headers, body)
         @method = method
-        @pathname = pathname
+        @uri = uri
         @headers = headers
-        @query = query
         @body = body
       end
 
@@ -25,7 +23,7 @@ module MyApiClient
       #
       # @return [Array<Object>] Arguments for Sawyer::Agent#call
       def to_sawyer_args
-        [method, pathname, body, { headers: headers, query: query }]
+        [method, uri.to_s, body, { headers: headers }]
       end
 
       # Generate metadata for bugsnag.
@@ -34,9 +32,8 @@ module MyApiClient
       # @return [Hash] Metadata for bugsnag
       def metadata
         {
-          line: "#{method.upcase} #{pathname}",
+          line: "#{method.upcase} #{uri}",
           headers: headers,
-          query: query,
           body: body,
         }.compact
       end
@@ -46,7 +43,7 @@ module MyApiClient
       #
       # @return [String] Contents as string
       def inspect
-        { method: method, pathname: pathname, headers: headers, query: query, body: body }.inspect
+        { method: method, uri: uri.to_s, headers: headers, body: body }.inspect
       end
     end
   end

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -3,6 +3,24 @@
 module MyApiClient
   # Description of Request
   module Request
+    HTTP_METHODS = %i[get post patch delete].freeze
+
+    HTTP_METHODS.each do |http_method|
+      class_eval <<~METHOD, __FILE__, __LINE__ + 1
+        # Description of ##{http_method}
+        #
+        # @param pathname [String]
+        # @param headers [Hash, nil]
+        # @param query [Hash, nil]
+        # @param body [Hash, nil]
+        # @return [Sawyer::Resouce] description_of_returned_object
+        def #{http_method}(pathname, headers: nil, query: nil, body: nil)
+          _request :#{http_method}, pathname, headers, query, body, logger
+        end
+      METHOD
+    end
+    alias put patch
+
     # Description of #_request
     #
     # @param http_method [Symbol] describe_http_method_here

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -15,7 +15,8 @@ module MyApiClient
         # @param body [Hash, nil]
         # @return [Sawyer::Resouce] description_of_returned_object
         def #{http_method}(pathname, headers: nil, query: nil, body: nil)
-          _request :#{http_method}, pathname, headers, query, body, logger
+          response = _request :#{http_method}, pathname, headers, query, body, logger
+          response.data
         end
       METHOD
     end
@@ -29,7 +30,7 @@ module MyApiClient
     # @param query [Hash, nil] describe_query_here
     # @param body [Hash, nil] describe_body_here
     # @param logger [::Logger] describe_logger_here
-    # @return [Sawyer::Resource] description_of_returned_object
+    # @return [Sawyer::Response] description_of_returned_object
     # rubocop:disable Metrics/ParameterLists
     def _request(http_method, pathname, headers, query, body, logger)
       processed_path = [common_path, pathname].join('/').gsub('//', '/')
@@ -67,7 +68,7 @@ module MyApiClient
     #
     # @param request_params [MyApiClient::Params::Request] describe_request_params_here
     # @param request_logger [MyApiClient::Logger] describe_request_logger_here
-    # @return [Sawyer::Resource] description_of_returned_object
+    # @return [Sawyer::Response] description_of_returned_object
     # @raise [MyApiClient::Error]
     def _execute(request_params, request_logger)
       request_logger.info('Start')
@@ -84,7 +85,7 @@ module MyApiClient
       raise e
     else
       request_logger.info("Success (#{response.status})")
-      response.data
+      response
     end
 
     # Description of #_verify

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -41,6 +41,28 @@ module MyApiClient
     end
     # rubocop:enable Metrics/ParameterLists
 
+    # Extracts schema and hostname from endpoint
+    #
+    # @example Extracts schema and hostname from 'https://example.com/path/to/api'
+    #   schema_and_hostname # => 'https://example.com'
+    # @return [String] description_of_returned_object
+    def schema_and_hostname
+      if _uri.default_port == _uri.port
+        "#{_uri.scheme}://#{_uri.host}"
+      else
+        "#{_uri.scheme}://#{_uri.host}:#{_uri.port}"
+      end
+    end
+
+    # Extracts pathname from endpoint
+    #
+    # @example Extracts pathname from 'https://example.com/path/to/api'
+    #   common_path # => 'path/to/api'
+    # @return [String] The pathanem
+    def common_path
+      _uri.path
+    end
+
     private
 
     # Description of #agent
@@ -62,6 +84,11 @@ module MyApiClient
             open_timeout: (http_open_timeout if respond_to?(:http_open_timeout)),
           }.compact
         )
+    end
+
+    # @return [URI] Returns a memoized URI instance
+    def _uri
+      @_uri ||= URI.parse(endpoint)
     end
 
     # Description of #_execute

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -17,7 +17,7 @@ module MyApiClient
         def #{http_method}(pathname, headers: nil, query: nil, body: nil)
           query_strings = query.present? ? '?' + query&.to_query : ''
           uri = URI.join(File.join(endpoint, pathname), query_strings)
-          response = _request :#{http_method}, uri, headers, body, logger
+          response = call(:_request, :#{http_method}, uri, headers, body, logger)
           response.data
         end
       METHOD
@@ -35,7 +35,7 @@ module MyApiClient
     def _request(http_method, uri, headers, body, logger)
       request_params = Params::Request.new(http_method, uri, headers, body)
       request_logger = Logger.new(logger, http_method, uri)
-      call(:_execute, request_params, request_logger)
+      _execute request_params, request_logger
     end
 
     private

--- a/spec/dummy_app/api_clients/example_api_client.rb
+++ b/spec/dummy_app/api_clients/example_api_client.rb
@@ -32,7 +32,6 @@ class ExampleApiClient < ApplicationApiClient
 
   # GET https://example.com/users
   #
-  # @param user_id [Integer] User ID which want to read
   # @return [Sawyer::Response] HTTP response parameter
   def get_users
     get 'users', headers: headers

--- a/spec/lib/my_api_client/base_spec.rb
+++ b/spec/lib/my_api_client/base_spec.rb
@@ -18,35 +18,4 @@ RSpec.describe MyApiClient::Base do
       expect(instance.logger).to be_kind_of(self.class::MyLogger)
     end
   end
-
-  described_class::HTTP_METHODS.each do |http_method|
-    describe "##{http_method}" do
-      subject(:execute) do
-        instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
-      end
-
-      before { allow(instance).to receive(:_request).and_return(response) }
-
-      let(:pathname) { 'path/to/resource' }
-      let(:headers) { { 'Content-Type': 'application/json;charset=UTF-8' } }
-      let(:query) { { key: 'value' } }
-      let(:body) { nil }
-      let(:response) { instance_double(Sawyer::Response, data: resource) }
-      let(:resource) { instance_double(Sawyer::Resource) }
-
-      it 'calls #_request method and then processes the response' do
-        execute
-        expect(instance)
-          .to have_received(:_request)
-          .with(http_method, pathname, headers, query, body, instance_of(self.class::MyLogger))
-          .ordered
-        expect(response)
-          .to have_received(:data)
-          .with(no_args)
-          .ordered
-      end
-
-      it { is_expected.to eq resource }
-    end
-  end
 end

--- a/spec/lib/my_api_client/base_spec.rb
+++ b/spec/lib/my_api_client/base_spec.rb
@@ -21,19 +21,32 @@ RSpec.describe MyApiClient::Base do
 
   described_class::HTTP_METHODS.each do |http_method|
     describe "##{http_method}" do
-      before { allow(instance).to receive(:_request) }
+      subject(:execute) do
+        instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
+      end
+
+      before { allow(instance).to receive(:_request).and_return(response) }
 
       let(:pathname) { 'path/to/resource' }
       let(:headers) { { 'Content-Type': 'application/json;charset=UTF-8' } }
       let(:query) { { key: 'value' } }
       let(:body) { nil }
+      let(:response) { instance_double(Sawyer::Response, data: resource) }
+      let(:resource) { instance_double(Sawyer::Resource) }
 
-      it do
-        instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
+      it 'calls #_request method and then processes the response' do
+        execute
         expect(instance)
           .to have_received(:_request)
           .with(http_method, pathname, headers, query, body, instance_of(self.class::MyLogger))
+          .ordered
+        expect(response)
+          .to have_received(:data)
+          .with(no_args)
+          .ordered
       end
+
+      it { is_expected.to eq resource }
     end
   end
 end

--- a/spec/lib/my_api_client/config_spec.rb
+++ b/spec/lib/my_api_client/config_spec.rb
@@ -40,40 +40,4 @@ RSpec.describe MyApiClient::Config do
       end
     end
   end
-
-  describe '#schema_and_hostname' do
-    context 'with domain name and path' do
-      before { self.class::MockClass.endpoint('https://example.com/path/to/resource') }
-
-      it 'extracts schema and hostname from endpoint' do
-        expect(instance.schema_and_hostname).to eq 'https://example.com'
-      end
-    end
-
-    context 'when given endpoint: "localhost:3000"' do
-      before { self.class::MockClass.endpoint('http://localhost:3000/path/to/resource') }
-
-      it 'extracts schema and hostname from endpoint' do
-        expect(instance.schema_and_hostname).to eq 'http://localhost:3000'
-      end
-    end
-  end
-
-  describe '#common_path' do
-    context 'with domain name and path' do
-      before { self.class::MockClass.endpoint('https://example.com/path/to/resource') }
-
-      it 'extracts pathname from endpoint' do
-        expect(instance.common_path).to eq '/path/to/resource'
-      end
-    end
-
-    context 'when given endpoint: "localhost:3000"' do
-      before { self.class::MockClass.endpoint('http://localhost:3000/path/to/resource') }
-
-      it 'extracts pathname from endpoint' do
-        expect(instance.common_path).to eq '/path/to/resource'
-      end
-    end
-  end
 end

--- a/spec/lib/my_api_client/logger_spec.rb
+++ b/spec/lib/my_api_client/logger_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe MyApiClient::Logger do
-  let(:instance) { described_class.new(logger, faraday, method, pathname) }
+  let(:instance) { described_class.new(logger, method, uri) }
   let(:logger) { instance_double(::Logger, logging_methods) }
   let(:logging_methods) { MyApiClient::Logger::LOG_LEVEL.zip([]).to_h }
-  let(:faraday) { instance_double(Faraday::Connection, build_exclusive_url: endpoint) }
-  let(:endpoint) { "https://example.com/#{pathname}" }
+  let(:uri) { URI.parse('https://example.com/path/to/resouce') }
   let(:method) { :get }
-  let(:pathname) { 'path/to/resouce' }
 
   MyApiClient::Logger::LOG_LEVEL.each do |log_level|
     describe "##{log_level}" do

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -1,23 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe MyApiClient::Params::Request do
-  let(:instance) { described_class.new(method, pathname, headers, query, body) }
+  let(:instance) { described_class.new(method, uri, headers, body) }
   let(:method) { :get }
-  let(:pathname) { 'path/to/resource' }
+  let(:uri) { URI.parse 'https://example.com/path/to/resource?key=value' }
   let(:headers) { { 'Content-Type': 'application/json; charset=utf-8' } }
-  let(:query) { { key: 'value' } }
   let(:body) { nil }
 
   describe '#to_sawyer_args' do
     it 'returns value formatted for arguments of Sawyer::Agent#call' do
       expect(instance.to_sawyer_args).to eq [
         :get,
-        'path/to/resource',
+        'https://example.com/path/to/resource?key=value',
         nil,
-        {
-          headers: { 'Content-Type': 'application/json; charset=utf-8' },
-          query: { key: 'value' },
-        },
+        { headers: { 'Content-Type': 'application/json; charset=utf-8' } },
       ]
     end
   end
@@ -26,20 +22,20 @@ RSpec.describe MyApiClient::Params::Request do
     context 'when body parameter is blank' do
       it 'returns hashed parameters which omitted body parameter' do
         expect(instance.metadata).to eq(
-          line: 'GET path/to/resource',
-          headers: { 'Content-Type': 'application/json; charset=utf-8' },
-          query: { key: 'value' }
+          line: 'GET https://example.com/path/to/resource?key=value',
+          headers: { 'Content-Type': 'application/json; charset=utf-8' }
         )
       end
     end
 
     context 'when query parameter is blank' do
+      let(:method) { :post }
+      let(:uri) { URI.parse 'https://example.com/path/to/resource' }
       let(:body) { { username: 'John Smith' } }
-      let(:query) { nil }
 
       it 'returns hashed parameters which omitted query parameter' do
         expect(instance.metadata).to eq(
-          line: 'GET path/to/resource',
+          line: 'POST https://example.com/path/to/resource',
           headers: { 'Content-Type': 'application/json; charset=utf-8' },
           body: { username: 'John Smith' }
         )
@@ -51,9 +47,9 @@ RSpec.describe MyApiClient::Params::Request do
     it 'returns contents as string for to be readable for human' do
       expect(instance.inspect)
         .to eq '{:method=>:get, ' \
-               ':pathname=>"path/to/resource", ' \
+               ':uri=>"https://example.com/path/to/resource?key=value", ' \
                ':headers=>{:"Content-Type"=>"application/json; charset=utf-8"}, ' \
-               ':query=>{:key=>"value"}, :body=>nil}'
+               ':body=>nil}'
     end
   end
 end

--- a/spec/lib/my_api_client/request_spec.rb
+++ b/spec/lib/my_api_client/request_spec.rb
@@ -219,4 +219,40 @@ RSpec.describe MyApiClient::Request do
       it_behaves_like 'to handle errors'
     end
   end
+
+  describe '#schema_and_hostname' do
+    context 'with domain name and path' do
+      before { self.class::MockClass.endpoint('https://example.com/path/to/resource') }
+
+      it 'extracts schema and hostname from endpoint' do
+        expect(instance.schema_and_hostname).to eq 'https://example.com'
+      end
+    end
+
+    context 'when given endpoint: "localhost:3000"' do
+      before { self.class::MockClass.endpoint('http://localhost:3000/path/to/resource') }
+
+      it 'extracts schema and hostname from endpoint' do
+        expect(instance.schema_and_hostname).to eq 'http://localhost:3000'
+      end
+    end
+  end
+
+  describe '#common_path' do
+    context 'with domain name and path' do
+      before { self.class::MockClass.endpoint('https://example.com/path/to/resource') }
+
+      it 'extracts pathname from endpoint' do
+        expect(instance.common_path).to eq '/path/to/resource'
+      end
+    end
+
+    context 'when given endpoint: "localhost:3000"' do
+      before { self.class::MockClass.endpoint('http://localhost:3000/path/to/resource') }
+
+      it 'extracts pathname from endpoint' do
+        expect(instance.common_path).to eq '/path/to/resource'
+      end
+    end
+  end
 end

--- a/spec/lib/my_api_client/request_spec.rb
+++ b/spec/lib/my_api_client/request_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe MyApiClient::Request do
       end
 
       it 'returns the API response' do
-        expect(request!).to eq resource
+        expect(request!).to eq response
       end
     end
 


### PR DESCRIPTION
## Breaking changes

### logging

**before**

```
I, [2020-02-02T15:26:53.788092 #93220]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts`: "Start"
I, [2020-02-02T15:26:55.760452 #93220]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts`: "Duration 1.97186 sec"
I, [2020-02-02T15:26:55.760739 #93220]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts`: "Success (200)"
```

**after**

Shows URL with query strings.

```
I, [2020-02-02T15:20:47.471040 #90870]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts?page=1&per_page=100&q=user%3Aryosuke_sato+category%3Aunsorted`: "Start"
I, [2020-02-02T15:20:49.516099 #90870]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts?page=1&per_page=100&q=user%3Aryosuke_sato+category%3Aunsorted`: "Duration 2.034907 sec"
I, [2020-02-02T15:20:49.516391 #90870]  INFO -- : API request `GET https://api.esa.io/v1/teams/feedforce/posts?page=1&per_page=100&q=user%3Aryosuke_sato+category%3Aunsorted`: "Success (200)"
```

### MyApiClient::Params::Request

**before**

```rb
request_params.metadata # =>
# {
#   line: 'GET path/to/resource',
#   headers: { 'Content-Type': 'application/json; charset=utf-8' },
#   query: { key: 'value' }
# }
```

**after**

The `#metadata` does not include `query` key and then includes full URL into `line` value.

```rb
request_params.metadata # =>
# {
#   line: 'GET https://example.com/path/to/resource?key=value',
#   headers: { 'Content-Type': 'application/json; charset=utf-8' }
# }
```