### PR TITLE
Raise an exception whenever an error is detected

### DIFF
--- a/lib/my_api_client/error_handling.rb
+++ b/lib/my_api_client/error_handling.rb
@@ -33,7 +33,7 @@ module MyApiClient
       #   as JsonPath expression.
       #   If specified `:forbid_nil`, it forbid `nil` at the response body.
       # @option with [Symbol]
-      #   Calls specified method when error detected
+      #   Calls specified method before raising exception when error detected.
       # @option raise [MyApiClient::Error]
       #   Raises specified error when an invalid response detected.
       #   Should be inherited `MyApiClient::Error` class.
@@ -42,7 +42,7 @@ module MyApiClient
       #   If the error detected, retries the API request. Requires `raise` option.
       #   You can set `true` or `retry_on` options (`wait` and `attempts`).
       # @yield [MyApiClient::Params::Params, MyApiClient::Request::Logger]
-      #   Executes the block when error detected.
+      #   Executes the block before raising exception when error detected.
       #   Forbid to be used with the` retry` option.
       def error_handling(**options, &block)
         options[:block] = block


### PR DESCRIPTION
Until now, using "with" or "block" in "error_handling" did not automatically raise an exception, but will now always raise an exception when an error is detected.

**Before**

```rb
error_handling json: { '$.errors.code': 10..19 }, with: :my_error_handling

def my_error_handling
  # Executes this method when an error is detected.
  # No exception is raised. You can raise an error if necessary.
end
```
```rb
error_handling status_code: 500..599 do |_params, logger|
  # Executes this block when an error is detected.
  # No exception is raised. You can raise an error if necessary.
end
```

**After**

```rb
error_handling json: { '$.errors.code': 10..19 }, with: :my_error_handling

def my_error_handling
  # Executes this method when an error is detected.
  # And then raise `MyApiClient::Error`.
end
```
```rb
error_handling status_code: 500..599 do |params, logger|
  # Executes this block when an error is detected.
  # And then raise `MyApiClient::Error`.
end
```