### PR TITLE
Support HTTP PUT method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,16 @@ commands:
       - rake_build
 
 jobs:
+  test_api:
+    parameters:
+      <<: *ruby_version
+    executor:
+      name: executor_for_api
+      ruby_version: << parameters.ruby_version >>
+    steps:
+      - setup:
+          ruby_version: << parameters.ruby_version >>
+      - run_rspec_for_api
   deploy_api:
     parameters:
       <<: *ruby_version
@@ -303,6 +313,7 @@ workflows:
           ruby_version:  '2.7'
           rails_version: '6.0'
           bundler_options: '--without integrations'
+      - test_api
       - rubocop
       - yardoc
       - upload-coverage:

--- a/example/api_clients/my_rest_api_client.rb
+++ b/example/api_clients/my_rest_api_client.rb
@@ -18,13 +18,19 @@ class MyRestApiClient < ApplicationApiClient
   end
 
   # POST rest
-  def create_post(title:)
+  def post_post(title:)
     body = { title: title }
     post 'rest', body: body, headers: headers
   end
 
-  # POST/PUT/PATCH rest/:id
-  def update_post(id:, title:)
+  # PUT rest/:id
+  def put_post(id:, title:)
+    body = { title: title }
+    put "rest/#{id}", body: body, headers: headers
+  end
+
+  # PATCH rest/:id
+  def patch_post(id:, title:)
     body = { title: title }
     patch "rest/#{id}", body: body, headers: headers
   end

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -11,7 +11,7 @@ module MyApiClient
     # Executes HTTP request with relative URI.
     #
     # @param http_method [Symbol]
-    #   HTTP method. e.g. `:get`, `:post`, `:patch` and `:delete`.
+    #   HTTP method. e.g. `:get`, `:post`, `:put`, `:patch` and `:delete`.
     # @param pathname [String]
     #   Pathname of the request target URL.
     #   It's joined with the defined by `endpoint`.
@@ -32,7 +32,7 @@ module MyApiClient
     # Executes HTTP request with absolute URI.
     #
     # @param http_method [Symbol]
-    #   HTTP method. e.g. `:get`, `:post`, `:patch` and `:delete`.
+    #   HTTP method. e.g. `:get`, `:post`, `:put`, `:patch` and `:delete`.
     # @param uri [URI]
     #   Request target URI including query strings.
     # @param headers [Hash, nil]

--- a/lib/my_api_client/request/basic.rb
+++ b/lib/my_api_client/request/basic.rb
@@ -4,7 +4,7 @@ module MyApiClient
   module Request
     # Provides basic HTTP request method.
     module Basic
-      HTTP_METHODS = %i[get post patch delete].freeze
+      HTTP_METHODS = %i[get post put patch delete].freeze
 
       HTTP_METHODS.each do |http_method|
         class_eval <<~METHOD, __FILE__, __LINE__ + 1
@@ -27,8 +27,6 @@ module MyApiClient
           end
         METHOD
       end
-
-      alias put patch
     end
   end
 end

--- a/my_api/spec/controllers/rest_controller_spec.rb
+++ b/my_api/spec/controllers/rest_controller_spec.rb
@@ -60,14 +60,32 @@ describe RestController, type: :controller do
   end
 
   describe '#update' do
-    let(:post) do
+    let(:the_post) do
       { id: 1, title: 'Modified title' }.to_json
     end
 
-    it 'returns a updated post' do
-      patch '/rest/:id', id: 1, title: 'Modified title'
-      expect(response.status).to eq 200
-      expect(response.body).to eq post
+    context 'with POST method' do
+      it 'returns a updated post' do
+        post '/rest/:id', id: 1, title: 'Modified title'
+        expect(response.status).to eq 200
+        expect(response.body).to eq the_post
+      end
+    end
+
+    context 'with PUT method' do
+      it 'returns a updated post' do
+        put '/rest/:id', id: 1, title: 'Modified title'
+        expect(response.status).to eq 200
+        expect(response.body).to eq the_post
+      end
+    end
+
+    context 'with PATCH method' do
+      it 'returns a updated post' do
+        patch '/rest/:id', id: 1, title: 'Modified title'
+        expect(response.status).to eq 200
+        expect(response.body).to eq the_post
+      end
     end
   end
 

--- a/spec/example/api_clients/my_rest_api_client_spec.rb
+++ b/spec/example/api_clients/my_rest_api_client_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe MyRestApiClient, type: :api_client do
     end
   end
 
-  describe '#create_post' do
-    subject(:api_request!) { api_client.create_post(title: 'New title') }
+  describe '#post_post' do
+    subject(:api_request!) { api_client.post_post(title: 'New title') }
 
     it 'requests to "POST rest"' do
       expect { api_request! }
@@ -92,8 +92,26 @@ RSpec.describe MyRestApiClient, type: :api_client do
     end
   end
 
-  describe '#update_post' do
-    subject(:api_request!) { api_client.update_post(id: 1, title: 'Modified title') }
+  describe '#put_post' do
+    subject(:api_request!) { api_client.put_post(id: 1, title: 'Modified title') }
+
+    it 'requests to "PATCH rest/:id"' do
+      expect { api_request! }
+        .to request_to(:put, URI.join(endpoint, 'rest/1'))
+        .with(headers: headers, body: { title: 'Modified title' })
+    end
+
+    it_behaves_like 'to handle errors' do
+      it do
+        expect { api_request! }
+          .not_to be_handled_as_an_error
+          .when_receive(status_code: 201, body: nil)
+      end
+    end
+  end
+
+  describe '#patch_post' do
+    subject(:api_request!) { api_client.patch_post(id: 1, title: 'Modified title') }
 
     it 'requests to "PATCH rest/:id"' do
       expect { api_request! }

--- a/spec/integrations/api_clients/my_rest_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_rest_api_client_spec.rb
@@ -35,15 +35,23 @@ RSpec.describe 'Integration test with My REST API', type: :integration do
 
   describe 'POST rest' do
     it 'returns a created post' do
-      response = api_client.create_post(title: 'New title')
+      response = api_client.post_post(title: 'New title')
       expect(response.id).to eq 4
       expect(response.title).to eq 'New title'
     end
   end
 
-  describe 'POST/PUT/PATCH rest/:id' do
+  describe 'PUT rest/:id' do
     it 'returns a updated post' do
-      response = api_client.update_post(id: 3, title: 'Modified title')
+      response = api_client.put_post(id: 3, title: 'Modified title')
+      expect(response.id).to eq 3
+      expect(response.title).to eq 'Modified title'
+    end
+  end
+
+  describe 'PATCH rest/:id' do
+    it 'returns a updated post' do
+      response = api_client.patch_post(id: 3, title: 'Modified title')
       expect(response.id).to eq 3
       expect(response.title).to eq 'Modified title'
     end


### PR DESCRIPTION
Currently, this gem does not support HTTP PUT method correctly.
There is `MyApiClient::Request::Basic#put` method but it calls HTTP `PATCH` method, because the `#put` method is alias of `#patch` method.

https://github.com/ryz310/my_api_client/blob/ea0e4a7272b318d0f5ea32e723f40c9180e53dae/lib/my_api_client/request/basic.rb#L31

Today, I've encountered an endpoint which accepts only HTTP `PUT` method, and I found that this API client can't call the API, so I fixed this implementation.