### PR TITLE
Stubbed pagination

### DIFF
--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -67,25 +67,24 @@ module MyApiClient
 
     private
 
-    # rubocop:disable Metrics/AbcSize
     def stubbing(instance, action, options)
-      case options
-      when Proc
-        allow(instance).to receive(action) { |*request| stub_as_resource(options.call(*request)) }
-      when Hash
-        if options[:raise].present?
-          exception = process_raise_option(options[:raise], options[:response])
-          allow(instance).to receive(action).and_raise(exception)
-        elsif options[:response]
-          allow(instance).to receive(action).and_return(stub_as_resource(options[:response]))
+      allow(instance).to receive(action) do |*request|
+        case options
+        when Proc
+          stub_as_resource(options.call(*request))
+        when Hash
+          if options[:raise].present?
+            raise process_raise_option(options[:raise], options[:response])
+          elsif options[:response]
+            stub_as_resource(options[:response])
+          else
+            stub_as_resource(options)
+          end
         else
-          allow(instance).to receive(action).and_return(stub_as_resource(options))
+          stub_as_resource(options)
         end
-      else
-        allow(instance).to receive(action).and_return(stub_as_resource(options))
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Provides a shorthand for `raise` option.
     # `MyApiClient::Error` requires `MyApiClient::Params::Params` instance on

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -79,16 +79,16 @@ module MyApiClient
       end
     end
 
-    def generate_stubbed_response(options, *request)
+    def generate_stubbed_response(options, *request) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       case options
       when Proc
         stub_as_resource(options.call(*request))
       when Hash
-        if options[:raise].present?
+        if options[:raise] # rubocop:disable Style/GuardClause
           raise process_raise_option(options[:raise], options[:response])
         elsif options[:response]
           stub_as_resource(options[:response])
-        elsif options[:pageable].present? && options[:pageable].is_a?(Enumerable)
+        elsif options[:pageable].is_a?(Enumerable)
           stub_as_pageable_resource(options[:pageable].each, *request)
         else
           stub_as_resource(options)

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -18,6 +18,9 @@ module MyApiClient
     # @example
     #   stub_api_client_all(
     #     ExampleApiClient,
+    #     get_users: {                                     # Returns an arbitrary pageable response
+    #       pageable: [ { id: 1 }, { id: 2 }]              # for `#pageable_get`.
+    #     },
     #     get_user: { response: { id: 1 } },               # Returns an arbitrary response.
     #     post_users: { id: 1 },                           # You can ommit `response` keyword.
     #     patch_user: ->(params) { { id: params[:id] } },  # Returns calculated result as response.
@@ -46,6 +49,9 @@ module MyApiClient
     # @example
     #   api_client = stub_api_client(
     #     ExampleApiClient,
+    #     get_users: {                                     # Returns an arbitrary pageable response
+    #       pageable: [ { id: 1 }, { id: 2 }]              # for `#pageable_get`.
+    #     },
     #     get_user: { response: { id: 1 } },               # Returns an arbitrary response.
     #     post_users: { id: 1 },                           # You can ommit `response` keyword.
     #     patch_user: ->(params) { { id: params[:id] } },  # Returns calculated result as response.

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -82,12 +82,24 @@ module MyApiClient
           raise process_raise_option(options[:raise], options[:response])
         elsif options[:response].present?
           stub_as_resource(options[:response])
+        elsif options[:pageable].present? && options[:pageable].is_a?(Enumerable)
+          stub_as_pageable_resource(options[:pageable].each, *request)
         else
           stub_as_resource(options)
         end
       else
         stub_as_resource(options)
       end
+    end
+
+    def stub_as_pageable_resource(pager, *request)
+      Enumerator.new do |y|
+        loop do
+          y << generate_stubbed_response(pager.next, *request)
+        rescue StopIteration
+          break
+        end
+      end.lazy
     end
 
     # Provides a shorthand for `raise` option.

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -86,7 +86,7 @@ module MyApiClient
       when Hash
         if options[:raise].present?
           raise process_raise_option(options[:raise], options[:response])
-        elsif options[:response].present?
+        elsif options[:response]
           stub_as_resource(options[:response])
         elsif options[:pageable].present? && options[:pageable].is_a?(Enumerable)
           stub_as_pageable_resource(options[:pageable].each, *request)

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -69,20 +69,24 @@ module MyApiClient
 
     def stubbing(instance, action, options)
       allow(instance).to receive(action) do |*request|
-        case options
-        when Proc
-          stub_as_resource(options.call(*request))
-        when Hash
-          if options[:raise].present?
-            raise process_raise_option(options[:raise], options[:response])
-          elsif options[:response]
-            stub_as_resource(options[:response])
-          else
-            stub_as_resource(options)
-          end
+        generate_stubbed_response(options, *request)
+      end
+    end
+
+    def generate_stubbed_response(options, *request)
+      case options
+      when Proc
+        stub_as_resource(options.call(*request))
+      when Hash
+        if options[:raise].present?
+          raise process_raise_option(options[:raise], options[:response])
+        elsif options[:response].present?
+          stub_as_resource(options[:response])
         else
           stub_as_resource(options)
         end
+      else
+        stub_as_resource(options)
       end
     end
 

--- a/spec/integrations/api_clients/my_error_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_error_api_client_spec.rb
@@ -1,44 +1,71 @@
 # frozen_string_literal: true
 
 require './example/api_clients/my_error_api_client'
+require 'my_api_client/rspec'
 
 RSpec.describe 'Integration test with My Error API', type: :integration do
-  let(:api_client) { MyErrorApiClient.new }
-
   describe 'GET error/:code' do
-    context 'with error code: 0' do
-      it do
-        expect { api_client.get_error(code: 0) }
-          .to raise_error(MyErrors::ErrorCode00)
+    shared_examples 'the API client' do
+      context 'with error code: 0' do
+        it do
+          expect { api_client.get_error(code: 0) }
+            .to raise_error(MyErrors::ErrorCode00)
+        end
+      end
+
+      context 'with error code: 10' do
+        it do
+          expect { api_client.get_error(code: 10) }
+            .to raise_error(MyErrors::ErrorCode10)
+        end
+      end
+
+      context 'with error code: 20 to 29' do
+        it do
+          expect { api_client.get_error(code: rand(20..29)) }
+            .to raise_error(MyErrors::ErrorCode2x)
+        end
+      end
+
+      context 'with error code: 30' do
+        it do
+          expect { api_client.get_error(code: 30) }
+            .to raise_error(MyErrors::ErrorCode30)
+        end
+      end
+
+      context 'with error code: other' do
+        it do
+          expect { api_client.get_error(code: 40) }
+            .to raise_error(MyErrors::ErrorCodeOther)
+        end
       end
     end
 
-    context 'with error code: 10' do
-      it do
-        expect { api_client.get_error(code: 10) }
-          .to raise_error(MyErrors::ErrorCode10)
-      end
+    context 'with real connection' do
+      let(:api_client) { MyErrorApiClient.new }
+
+      it_behaves_like 'the API client'
     end
 
-    context 'with error code: 20 to 29' do
-      it do
-        expect { api_client.get_error(code: rand(20..29)) }
-          .to raise_error(MyErrors::ErrorCode2x)
-      end
-    end
+    context 'with stubbed API client' do
+      let(:api_client) { stub_api_client(MyErrorApiClient, get_error: get_error) }
 
-    context 'with error code: 30' do
-      it do
-        expect { api_client.get_error(code: 30) }
-          .to raise_error(MyErrors::ErrorCode30)
+      let(:get_error) do
+        lambda do |params|
+          exception =
+            case params[:code]
+            when 0      then MyErrors::ErrorCode00
+            when 10     then MyErrors::ErrorCode10
+            when 20..29 then MyErrors::ErrorCode2x
+            when 30     then MyErrors::ErrorCode30
+            else;            MyErrors::ErrorCodeOther
+            end
+          raise exception, MyApiClient::Params::Params.new(nil, nil)
+        end
       end
-    end
 
-    context 'with error code: other' do
-      it do
-        expect { api_client.get_error(code: 40) }
-          .to raise_error(MyErrors::ErrorCodeOther)
-      end
+      it_behaves_like 'the API client'
     end
   end
 end

--- a/spec/integrations/api_clients/my_pagination_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_pagination_api_client_spec.rb
@@ -1,16 +1,40 @@
 # frozen_string_literal: true
 
 require './example/api_clients/my_pagination_api_client'
+require 'my_api_client/rspec'
 
 RSpec.describe 'Integration test with My Pagination API', type: :integration do
-  let(:api_client) { MyPaginationApiClient.new }
-
   describe 'GET pagination' do
-    it 'returns an array of posts ordered by id' do
-      pageable_get = api_client.pagination
-      expect(pageable_get.next.page).to eq 1
-      expect(pageable_get.next.page).to eq 2
-      expect(pageable_get.next.page).to eq 3
+    shared_examples 'the API client' do
+      it 'returns an array of posts ordered by id' do
+        pageable_get = api_client.pagination
+        expect(pageable_get.next.page).to eq 1
+        expect(pageable_get.next.page).to eq 2
+        expect(pageable_get.next.page).to eq 3
+      end
+    end
+
+    context 'with real connection' do
+      let(:api_client) { MyPaginationApiClient.new }
+
+      it_behaves_like 'the API client'
+    end
+
+    context 'with stubbed API client' do
+      let(:api_client) do
+        stub_api_client(
+          MyPaginationApiClient,
+          pagination: {
+            pageable: [
+              { page: 1 },
+              { page: 2 },
+              { page: 3 },
+            ],
+          }
+        )
+      end
+
+      it_behaves_like 'the API client'
     end
   end
 end

--- a/spec/integrations/api_clients/my_pagination_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_pagination_api_client_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe 'Integration test with My Pagination API', type: :integration do
   describe 'GET pagination' do
     shared_examples 'the API client' do
       it 'returns an array of posts ordered by id' do
-        pageable_response = api_client.pagination
-        expect(pageable_response.next.page).to eq 1
-        expect(pageable_response.next.page).to eq 2
-        expect(pageable_response.next.page).to eq 3
+        api_client.pagination.each.with_index(1) do |response, idx|
+          expect(response.page).to eq idx
+        end
       end
     end
 

--- a/spec/integrations/api_clients/my_pagination_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_pagination_api_client_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe 'Integration test with My Pagination API', type: :integration do
   describe 'GET pagination' do
     shared_examples 'the API client' do
       it 'returns an array of posts ordered by id' do
-        pageable_get = api_client.pagination
-        expect(pageable_get.next.page).to eq 1
-        expect(pageable_get.next.page).to eq 2
-        expect(pageable_get.next.page).to eq 3
+        pageable_response = api_client.pagination
+        expect(pageable_response.next.page).to eq 1
+        expect(pageable_response.next.page).to eq 2
+        expect(pageable_response.next.page).to eq 3
       end
     end
 

--- a/spec/integrations/api_clients/my_rest_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_rest_api_client_spec.rb
@@ -1,66 +1,95 @@
 # frozen_string_literal: true
 
 require './example/api_clients/my_rest_api_client'
+require 'my_api_client/rspec'
 
 RSpec.describe 'Integration test with My REST API', type: :integration do
-  let(:api_client) { MyRestApiClient.new }
+  shared_examples 'the API client' do
+    describe 'GET rest' do
+      context 'with order: :asc' do
+        it 'returns an array of posts ordered by id' do
+          response = api_client.get_posts(order: :asc)
+          expect(response[0].id).to eq 1
+          expect(response[1].id).to eq 2
+          expect(response[2].id).to eq 3
+        end
+      end
 
-  describe 'GET rest' do
-    context 'with order: :asc' do
-      it 'returns an array of posts ordered by id' do
-        response = api_client.get_posts(order: :asc)
-        expect(response[0].id).to eq 1
-        expect(response[1].id).to eq 2
-        expect(response[2].id).to eq 3
+      context 'with order: :desc' do
+        it 'returns an array of posts reverse ordered by id' do
+          response = api_client.get_posts(order: :desc)
+          expect(response[0].id).to eq 3
+          expect(response[1].id).to eq 2
+          expect(response[2].id).to eq 1
+        end
       end
     end
 
-    context 'with order: :desc' do
-      it 'returns an array of posts reverse ordered by id' do
-        response = api_client.get_posts(order: :desc)
-        expect(response[0].id).to eq 3
-        expect(response[1].id).to eq 2
-        expect(response[2].id).to eq 1
+    describe 'GET rest/:id' do
+      it 'returns a post' do
+        response = api_client.get_post(id: 2)
+        expect(response.id).to eq 2
+        expect(response.title).to eq 'Title 2'
+      end
+    end
+
+    describe 'POST rest' do
+      it 'returns a created post' do
+        response = api_client.post_post(title: 'New title')
+        expect(response.id).to eq 4
+        expect(response.title).to eq 'New title'
+      end
+    end
+
+    describe 'PUT rest/:id' do
+      it 'returns a updated post' do
+        response = api_client.put_post(id: 3, title: 'Modified title')
+        expect(response.id).to eq 3
+        expect(response.title).to eq 'Modified title'
+      end
+    end
+
+    describe 'PATCH rest/:id' do
+      it 'returns a updated post' do
+        response = api_client.patch_post(id: 3, title: 'Modified title')
+        expect(response.id).to eq 3
+        expect(response.title).to eq 'Modified title'
+      end
+    end
+
+    describe 'DELETE rest/:id' do
+      it 'returns no contents' do
+        response = api_client.delete_post(id: 1)
+        expect(response).to be_nil
       end
     end
   end
 
-  describe 'GET rest/:id' do
-    it 'returns a post' do
-      response = api_client.get_post(id: 2)
-      expect(response.id).to eq 2
-      expect(response.title).to eq 'Title 2'
-    end
+  context 'with real connection' do
+    let(:api_client) { MyRestApiClient.new }
+
+    it_behaves_like 'the API client'
   end
 
-  describe 'POST rest' do
-    it 'returns a created post' do
-      response = api_client.post_post(title: 'New title')
-      expect(response.id).to eq 4
-      expect(response.title).to eq 'New title'
+  context 'with stubbed API client' do
+    let(:api_client) do
+      stub_api_client(
+        MyRestApiClient,
+        get_posts: get_posts,
+        get_post: ->(params) { { id: params[:id], title: "Title #{params[:id]}" } },
+        post_post: { response: { id: 4, title: 'New title' } },
+        put_post: ->(params) { { id: params[:id], title: params[:title] } },
+        patch_post: ->(params) { { id: params[:id], title: params[:title] } },
+        delete_post: nil
+      )
     end
-  end
 
-  describe 'PUT rest/:id' do
-    it 'returns a updated post' do
-      response = api_client.put_post(id: 3, title: 'Modified title')
-      expect(response.id).to eq 3
-      expect(response.title).to eq 'Modified title'
+    let(:get_posts) do
+      lambda do |params|
+        (1..3).map { |id| { id: id } }.tap { |me| me.reverse! if params[:order] == :desc }
+      end
     end
-  end
 
-  describe 'PATCH rest/:id' do
-    it 'returns a updated post' do
-      response = api_client.patch_post(id: 3, title: 'Modified title')
-      expect(response.id).to eq 3
-      expect(response.title).to eq 'Modified title'
-    end
-  end
-
-  describe 'DELETE rest/:id' do
-    it 'returns no contents' do
-      response = api_client.delete_post(id: 1)
-      expect(response).to be_nil
-    end
+    it_behaves_like 'the API client'
   end
 end

--- a/spec/integrations/api_clients/my_status_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_status_api_client_spec.rb
@@ -1,51 +1,79 @@
 # frozen_string_literal: true
 
 require './example/api_clients/my_status_api_client'
+require 'my_api_client/rspec'
 
 RSpec.describe 'Integration test with My Status API', type: :integration do
-  let(:api_client) { MyStatusApiClient.new }
+  shared_examples 'the API client' do
+    describe 'GET status/:status' do
+      context 'with status code: 200' do
+        it 'returns specified ID and message' do
+          response = api_client.get_status(status: 200)
+          expect(response.message).to eq 'You requested status code: 200'
+        end
+      end
 
-  describe 'GET status/:status' do
-    context 'with status code: 200' do
-      it 'returns specified ID and message' do
-        response = api_client.get_status(status: 200)
-        expect(response.message).to eq 'You requested status code: 200'
+      context 'with status code: 400' do
+        it do
+          expect { api_client.get_status(status: 400) }
+            .to raise_error(MyErrors::BadRequest)
+        end
+      end
+
+      context 'with status code: 401' do
+        it do
+          expect { api_client.get_status(status: 401) }
+            .to raise_error(MyErrors::Unauthorized)
+        end
+      end
+
+      context 'with status code: 403' do
+        it do
+          expect { api_client.get_status(status: 403) }
+            .to raise_error(MyErrors::Forbidden)
+        end
+      end
+
+      context 'with status code: 404' do
+        it do
+          expect { api_client.get_status(status: 404) }
+            .to raise_error(MyApiClient::ClientError::NotFound)
+        end
+      end
+
+      context 'with status code: 500' do
+        it do
+          expect { api_client.get_status(status: 500) }
+            .to raise_error(MyApiClient::ServerError::InternalServerError)
+        end
+      end
+    end
+  end
+
+  context 'with real connection' do
+    let(:api_client) { MyStatusApiClient.new }
+
+    it_behaves_like 'the API client'
+  end
+
+  context 'with stubbed API client' do
+    let(:api_client) { stub_api_client(MyStatusApiClient, get_status: get_status) }
+
+    let(:get_status) do
+      lambda do |params|
+        exception =
+          case params[:status]
+          when 400 then MyErrors::BadRequest
+          when 401 then MyErrors::Unauthorized
+          when 403 then MyErrors::Forbidden
+          when 404 then MyApiClient::ClientError::NotFound
+          when 500 then MyApiClient::ServerError::InternalServerError
+          else; return { message: "You requested status code: #{params[:status]}" }
+          end
+        raise exception, MyApiClient::Params::Params.new(nil, nil)
       end
     end
 
-    context 'with status code: 400' do
-      it do
-        expect { api_client.get_status(status: 400) }
-          .to raise_error(MyErrors::BadRequest)
-      end
-    end
-
-    context 'with status code: 401' do
-      it do
-        expect { api_client.get_status(status: 401) }
-          .to raise_error(MyErrors::Unauthorized)
-      end
-    end
-
-    context 'with status code: 403' do
-      it do
-        expect { api_client.get_status(status: 403) }
-          .to raise_error(MyErrors::Forbidden)
-      end
-    end
-
-    context 'with status code: 404' do
-      it do
-        expect { api_client.get_status(status: 404) }
-          .to raise_error(MyApiClient::ClientError::NotFound)
-      end
-    end
-
-    context 'with status code: 500' do
-      it do
-        expect { api_client.get_status(status: 500) }
-          .to raise_error(MyApiClient::ServerError::InternalServerError)
-      end
-    end
+    it_behaves_like 'the API client'
   end
 end

--- a/spec/lib/my_api_client/rspec/stub_spec.rb
+++ b/spec/lib/my_api_client/rspec/stub_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe MyApiClient::Stub do
       end
 
       context 'with not an MyApiClient::Error class or instance' do
-        let(:stubbing!) do
+        let(:api_client) do
           stub_api_client(
             example_api_client,
             request: { raise: 1 },
@@ -129,7 +129,10 @@ RSpec.describe MyApiClient::Stub do
         end
 
         it 'raises exception' do
-          expect { stubbing! }.to raise_error(/Unsupported error class was set/)
+          expect { api_client.request(user_id: 1) }
+            .to raise_error(/Unsupported error class was set/)
+          expect { api_client.request_all }
+            .to raise_error(/Unsupported error class was set/)
         end
       end
     end
@@ -213,7 +216,7 @@ RSpec.describe MyApiClient::Stub do
       end
 
       context 'with not an MyApiClient::Error class or instance' do
-        let(:stubbing!) do
+        let(:api_client) do
           stub_api_client(
             example_api_client,
             request: { raise: 1 },
@@ -222,7 +225,10 @@ RSpec.describe MyApiClient::Stub do
         end
 
         it 'raises exception' do
-          expect { stubbing! }.to raise_error(/Unsupported error class was set/)
+          expect { api_client.request(user_id: 1) }
+            .to raise_error(/Unsupported error class was set/)
+          expect { api_client.request_all }
+            .to raise_error(/Unsupported error class was set/)
         end
       end
     end

--- a/spec/lib/my_api_client/rspec/stub_spec.rb
+++ b/spec/lib/my_api_client/rspec/stub_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe MyApiClient::Stub do
 
       let(:number) { rand(100) }
 
-      it 'stubs the ApiClient to return params set in Proc' do
+      it 'stubs to return params set in Proc' do
         response1 = api_client.request(user_id: number)
         expect(response1.id).to eq number
         response2 = api_client.request_all
@@ -88,7 +88,7 @@ RSpec.describe MyApiClient::Stub do
           )
         end
 
-        it 'stubs ApiClient to raise error set in `raise`' do
+        it 'stubs to raise error set in `raise`' do
           expect { api_client.request(user_id: 1) }.to raise_error(error)
           expect { api_client.request_all }.to raise_error(error)
         end
@@ -113,7 +113,7 @@ RSpec.describe MyApiClient::Stub do
           )
         end
 
-        it 'stubs ApiClient to raise error set in `raise`' do
+        it 'stubs to raise error set in `raise`' do
           expect { api_client.request(user_id: 1) }.to raise_error(MyApiClient::ServerError)
           expect { api_client.request_all }.to raise_error(MyApiClient::ServerError)
         end
@@ -146,7 +146,7 @@ RSpec.describe MyApiClient::Stub do
         )
       end
 
-      it 'stubs the ApiClient to return params set in `response`' do
+      it 'stubs to return params set in `response`' do
         response1 = api_client.request(user_id: 1)
         expect(response1.id).to eq 12_345
         response2 = api_client.request_all
@@ -164,19 +164,19 @@ RSpec.describe MyApiClient::Stub do
           )
         end
 
-        it 'stubs ApiClient to raise error set in `raise`' do
+        it 'stubs to raise error set in `raise`' do
           expect { api_client.request(user_id: 1) }.to raise_error(error)
           expect { api_client.request_all }.to raise_error(error)
         end
 
-        it 'stubs ApiClient to return params set in `response`' do
+        it 'stubs to return params set in `response`' do
           api_client.request(user_id: 1)
         rescue error => e
           response_body = e.params.response.data.to_h
           expect(response_body).to eq(message: 'error 1')
         end
 
-        it 'stubs ApiClient to return params with metadata' do
+        it 'stubs to return params with metadata' do
           api_client.request_all
         rescue error => e
           expect(e.params.metadata).to eq(
@@ -207,7 +207,7 @@ RSpec.describe MyApiClient::Stub do
           )
         end
 
-        it 'stubs ApiClient to raise error set in `raise`' do
+        it 'stubs to raise error set in `raise`' do
           expect { api_client.request(user_id: 1) }
             .to raise_error(/the `response` option is ignored/)
           expect { api_client.request_all }
@@ -255,7 +255,7 @@ RSpec.describe MyApiClient::Stub do
         )
       end
 
-      it do
+      it 'stubs to pageable response' do # rubocop:disable RSpec/MultipleExpectations
         pageable_response = api_client.request(user_id: 1)
         response_1st_page = pageable_response.next
         expect(response_1st_page.page).to eq 1
@@ -270,7 +270,7 @@ RSpec.describe MyApiClient::Stub do
         expect { pageable_response.next }.to raise_error(MyApiClient::ClientError::IamTeapot)
       end
 
-      it do
+      it 'is able to be endless pageable response' do
         expect { |b| api_client.request_all.take(5).map(&:page).each(&b) }
           .to yield_successive_args(1, 2, 3, 4, 5)
       end

--- a/spec/lib/my_api_client/rspec/stub_spec.rb
+++ b/spec/lib/my_api_client/rspec/stub_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe MyApiClient::Stub do
         stub_api_client(
           example_api_client,
           request: { response: { id: 12_345 } },
-          request_all: { response: [10, 20, 30] }
+          request_all: { response: '' }
         )
       end
 
@@ -150,7 +150,7 @@ RSpec.describe MyApiClient::Stub do
         response1 = api_client.request(user_id: 1)
         expect(response1.id).to eq 12_345
         response2 = api_client.request_all
-        expect(response2).to eq [10, 20, 30]
+        expect(response2).to eq ''
       end
     end
 


### PR DESCRIPTION
Add `pageable` option to `#stub_api_client`:

```rb
stub_api_client(
  MyPaginationApiClient,
  pagination: {
    pageable: [
      { page: 1 },
      { page: 2 },
      { page: 3 },
    ],
  }
)

MyPaginationApiClient.new.pagination.each do |response|
  response.page #=> 1, 2, 3
end
```
