### PR TITLE
Stubbing status code on testing

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -630,14 +630,15 @@ stub_api_client_all(ExampleApiClient, request: { raise: MyApiClient::Error })
 expect { execute_api_request }.to raise_error(MyApiClient::Error)
 ```
 
-なお、発生した例外に含まれるレスポンスパラメータもスタブ化したい場合は、 `response` オプションと同時に指定することが可能です。
+なお、発生した例外に含まれるレスポンスパラメータやステータスコードもスタブ化したい場合は、 `response` オプションと同時に指定することが可能です。
 
 ```ruby
 stub_api_client_all(
   ExampleApiClient,
   request: {
     raise: MyApiClient::Error,
-    response: { message: 'error' }
+    response: { message: 'error' },
+    status_code: 429
   }
 )
 
@@ -646,6 +647,8 @@ begin
 rescue MyApiClient::Error => e
   response_body = e.params.response.data.to_h
   expect(response_body).to eq(message: 'error')
+  status_code = e.params.response.status
+  expect(status_code).to eq(429)
 end
 ```
 


### PR DESCRIPTION
Resolve #563

Add new feature for stubbing status code on testing.
You can use it as following:

```ruby
stub_api_client_all(
  ExampleApiClient,
  request: {
    raise: MyApiClient::Error,
    response: { message: 'error' },
    status_code: 429
  }
)

begin
  ExampleApiClient.new.request(user_id: 1)
rescue MyApiClient::Error => e
  status_code = e.params.response.status
  expect(status_code).to eq(429)
end
```
