### PR TITLE
Support response header error handling

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -221,6 +221,22 @@ error_handling json: { '$.errors.code': 10..19 }, with: :my_error_handling
 }
 ```
 
+`headers` には `Hash` の Key に レスポンスのヘッダーキーを指定して、 Value とマッチするかどうかでエラーハンドリングできます。Value には `String` `Regexp` が指定可能です。
+
+上記の場合であれば、以下のような レスポンスヘッダー にマッチします。
+
+```ruby
+error_handling headers: { 'www-authenticate': /invalid token/ }, with: :my_error_handling
+```
+
+```text
+cache-control: no-cache, no-store, max-age=0, must-revalidate
+content-type: application/json
+www-authenticate: Bearer error="invalid_token", error_description="invalid token"
+content-length: 104
+```
+
+
 `with` にはインスタンスメソッド名を指定することで、エラーを検出した際、例外を発生させる前に任意のメソッドを実行させることができます。メソッドに渡される引数は `block` 定義の場合と同じく `params` と `logger` です。なお、 `block` と `with` は同時には利用できません。
 
 ```ruby

--- a/README.jp.md
+++ b/README.jp.md
@@ -223,11 +223,12 @@ error_handling json: { '$.errors.code': 10..19 }, with: :my_error_handling
 
 `headers` には `Hash` の Key に レスポンスのヘッダーキーを指定して、 Value とマッチするかどうかでエラーハンドリングできます。Value には `String` `Regexp` が指定可能です。
 
-上記の場合であれば、以下のような レスポンスヘッダー にマッチします。
 
 ```ruby
 error_handling headers: { 'www-authenticate': /invalid token/ }, with: :my_error_handling
 ```
+
+上記の場合であれば、以下のような レスポンスヘッダー にマッチします。
 
 ```text
 cache-control: no-cache, no-store, max-age=0, must-revalidate

--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ In the above case, it matches JSON as below:
 
 For `headers`, specify response header for the Key of `Hash`, get an arbitrary value from the response header, and check whether it matches value. You can handle errors. You can specify `String` and `Regexp` for value.
 
-In the above case, it matches response header as below:
-
 ```ruby
 error_handling headers: { 'www-authenticate': /invalid token/ }, with: :my_error_handling
 ```
+
+In the above case, it matches response header as below:
 
 ```text
 cache-control: no-cache, no-store, max-age=0, must-revalidate

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ In the above case, it matches JSON as below:
 }
 ```
 
+For `headers`, specify response header for the Key of `Hash`, get an arbitrary value from the response header, and check whether it matches value. You can handle errors. You can specify `String` and `Regexp` for value.
+
+In the above case, it matches response header as below:
+
+```ruby
+error_handling headers: { 'www-authenticate': /invalid token/ }, with: :my_error_handling
+```
+
+```text
+cache-control: no-cache, no-store, max-age=0, must-revalidate
+content-type: application/json
+www-authenticate: Bearer error="invalid_token", error_description="invalid token"
+content-length: 104
+```
+
 By specifying the instance method name in `with`, when an error is detected, any method can be executed before raising an exception. The arguments passed to the method are `params` and `logger` as in the `block` definition. Note that `block` and` with` cannot be used at the same time.
 
 ```ruby

--- a/example/api_clients/my_errors.rb
+++ b/example/api_clients/my_errors.rb
@@ -24,4 +24,22 @@ module MyErrors
 
   # Error code: other
   class ErrorCodeOther < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is invalid
+  class FirstHeaderIsInvalid < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is 100 to 199
+  class FirstHeaderIs1xx < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is 0
+  class FirstHeaderIs00 < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is 30
+  class FirstHeaderIs30 < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is 30 and status is 400
+  class FirstHeaderIs30WithNotFound < MyApiClient::ClientError; end
+
+  # Header: X-First-Header is 200 to 299 and X-Second-Header is 300 to 399
+  class MultipleHeaderIsInvalid < MyApiClient::ClientError; end
 end

--- a/example/api_clients/my_errors.rb
+++ b/example/api_clients/my_errors.rb
@@ -25,21 +25,12 @@ module MyErrors
   # Error code: other
   class ErrorCodeOther < MyApiClient::ClientError; end
 
-  # Header: X-First-Header is invalid
+  # Header: X-First-Header has invalid
   class FirstHeaderIsInvalid < MyApiClient::ClientError; end
 
-  # Header: X-First-Header is 100 to 199
-  class FirstHeaderIs1xx < MyApiClient::ClientError; end
+  # Header: X-First-Header has nothing and status is 404
+  class FirstHeaderHasNothingAndNotFound < MyApiClient::ClientError; end
 
-  # Header: X-First-Header is 0
-  class FirstHeaderIs00 < MyApiClient::ClientError; end
-
-  # Header: X-First-Header is 30
-  class FirstHeaderIs30 < MyApiClient::ClientError; end
-
-  # Header: X-First-Header is 30 and status is 400
-  class FirstHeaderIs30WithNotFound < MyApiClient::ClientError; end
-
-  # Header: X-First-Header is 200 to 299 and X-Second-Header is 300 to 399
+  # Header: X-First-Header has unknown and X-Second-Header has error
   class MultipleHeaderIsInvalid < MyApiClient::ClientError; end
 end

--- a/example/api_clients/my_header_api_client.rb
+++ b/example/api_clients/my_header_api_client.rb
@@ -8,26 +8,21 @@ class MyHeaderApiClient < ApplicationApiClient
   error_handling headers: { 'X-First-Header': /invalid/ },
                  raise: MyErrors::FirstHeaderIsInvalid
 
-  error_handling headers: { 'X-First-Header': :zero? },
-                 raise: MyErrors::FirstHeaderIs00
-
-  error_handling headers: { 'X-First-Header': 100..199 },
-                 raise: MyErrors::FirstHeaderIs1xx
-
   error_handling headers: {
-                   'X-First-Header': 200..299,
-                   'X-Second-Header': 300..399,
+                   'X-First-Header': /unknown/,
+                   'X-Second-Header': /error/,
                  },
                  raise: MyErrors::MultipleHeaderIsInvalid
 
-    error_handling headers: { 'X-First-Header': 30 },
-                  raise: MyErrors::FirstHeaderIs30
-
-  error_handling headers: { 'X-First-Header': 30 },
+  error_handling headers: { 'X-First-Header': /nothing/ },
                  status_code: 404,
-                 raise: MyErrors::FirstHeaderIs30WithNotFound
+                 raise: MyErrors::FirstHeaderHasNothingAndNotFound
 
   # GET header
+  #
+  # @param first_header [String] X-First-Header
+  # @param second_header [String] X-Second-Header
+  # @return [Sawyer::Resource]
   def get_header(first_header:, second_header:)
     get 'header', headers: headers, query: {
       'X-First-Header': first_header,

--- a/example/api_clients/my_header_api_client.rb
+++ b/example/api_clients/my_header_api_client.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative 'application_api_client'
+
+# An usage example of the `my_api_client`.
+# See also: my_api/app/controllers/header_controller.rb
+class MyHeaderApiClient < ApplicationApiClient
+  error_handling headers: { 'X-First-Header': /invalid/ },
+                 raise: MyErrors::FirstHeaderIsInvalid
+
+  error_handling headers: { 'X-First-Header': :zero? },
+                 raise: MyErrors::FirstHeaderIs00
+
+  error_handling headers: { 'X-First-Header': 100..199 },
+                 raise: MyErrors::FirstHeaderIs1xx
+
+  error_handling headers: {
+                   'X-First-Header': 200..299,
+                   'X-Second-Header': 300..399,
+                 },
+                 raise: MyErrors::MultipleHeaderIsInvalid
+
+    error_handling headers: { 'X-First-Header': 30 },
+                  raise: MyErrors::FirstHeaderIs30
+
+  error_handling headers: { 'X-First-Header': 30 },
+                 status_code: 404,
+                 raise: MyErrors::FirstHeaderIs30WithNotFound
+
+  # GET header
+  def get_header(first_header:, second_header:)
+    get 'header', headers: headers, query: {
+      'X-First-Header': first_header,
+      'X-Second-Header': second_header,
+    }.compact
+  end
+
+  private
+
+  def headers
+    { 'Content-Type': 'application/json;charset=UTF-8' }
+  end
+end

--- a/lib/my_api_client/error_handling/generator.rb
+++ b/lib/my_api_client/error_handling/generator.rb
@@ -36,7 +36,7 @@ module MyApiClient
 
       def call
         return unless match?(_status_code, _response.status)
-        return unless match_all?(_json, _response.body)
+        return unless match_body?(_json, _response.body)
 
         generate_error_handler
       end
@@ -102,7 +102,7 @@ module MyApiClient
         end
       end
 
-      def match_all?(json, response_body)
+      def match_body?(json, response_body)
         return true if json.nil?
         return response_body.nil? if json == :forbid_nil
         return false if response_body.blank?

--- a/lib/my_api_client/error_handling/generator.rb
+++ b/lib/my_api_client/error_handling/generator.rb
@@ -16,7 +16,6 @@ module MyApiClient
       #   Verifies response HTTP status code and raises error if matched
       # @option headers [String, Regexp]
       #   Verifies response HTTP header and raises error if matched
-      #   If specified `:forbid_nil`, it forbid `nil` on response_header.
       # @option json [Hash, Symbol]
       #   Verifies response body as JSON and raises error if matched.
       #   If specified `:forbid_nil`, it forbid `nil` on response_body.
@@ -108,7 +107,6 @@ module MyApiClient
 
       def match_headers?(headers, response_headers)
         return true if headers.nil?
-        return response_headers.nil? if headers == :forbid_nil
         return false if response_headers.blank?
 
         headers.all? do |header_key, operator|

--- a/lib/my_api_client/error_handling/generator.rb
+++ b/lib/my_api_client/error_handling/generator.rb
@@ -14,6 +14,9 @@ module MyApiClient
       #   The target of verifying
       # @option status_code [String, Range, Integer, Regexp]
       #   Verifies response HTTP status code and raises error if matched
+      # @option headers [String, Regexp]
+      #   Verifies response HTTP header and raises error if matched
+      #   If specified `:forbid_nil`, it forbid `nil` on response_header.
       # @option json [Hash, Symbol]
       #   Verifies response body as JSON and raises error if matched.
       #   If specified `:forbid_nil`, it forbid `nil` on response_body.

--- a/my_api/app/controllers/header_controller.rb
+++ b/my_api/app/controllers/header_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# The header API
+class HeaderController < ApplicationController
+  # GET header
+  def index
+    params.each do |header_name, header_value|
+      response.set_header(header_name, header_value)
+    end
+    render status: :ok, json: {}
+  end
+end

--- a/my_api/config/routes.rb
+++ b/my_api/config/routes.rb
@@ -6,6 +6,7 @@ Jets.application.routes.draw do
   resources 'rest', only: %i[index show create update delete]
 
   get 'status/:status', to: 'status#show'
+  get 'header', to: 'header#index'
   get 'error/:code', to: 'error#show'
   get 'pagination', to: 'pagination#index'
 

--- a/my_api/spec/controllers/header_controller_spec.rb
+++ b/my_api/spec/controllers/header_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe HeaderController do
+  describe '#index' do
+    context 'when request header with a header' do
+      let(:headers) { { 'x-header': 'value' } }
+
+      it 'returns 200 OK request with header' do
+        get '/header', query: headers
+        expect(response.status).to eq 200
+        expect(response.body).to eq '{}'
+        expect(response.headers['x-header']).to eq 'value'
+      end
+    end
+
+    context 'when request header with multiple headers' do
+      let(:headers) do
+        {
+          'x-header': 'value1',
+          'x-second-header': 'value2',
+        }
+      end
+
+      it 'returns 200 OK request with header' do
+        get '/header', query: headers
+        expect(response.status).to eq 200
+        expect(response.body).to eq '{}'
+        expect(response.headers['x-header']).to eq 'value1'
+        expect(response.headers['x-second-header']).to eq 'value2'
+      end
+    end
+  end
+end

--- a/spec/example/api_clients/my_header_api_client_spec.rb
+++ b/spec/example/api_clients/my_header_api_client_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'my_api_client/rspec'
+require './example/api_clients/my_header_api_client'
+
+RSpec.describe MyHeaderApiClient, type: :api_client do
+  let(:api_client) { described_class.new }
+  let(:endpoint) { ENV.fetch('MY_API_ENDPOINT', nil) }
+  let(:headers) do
+    { 'Content-Type': 'application/json;charset=UTF-8' }
+  end
+
+  describe '#get_header' do
+    subject(:api_request!) do
+      api_client.get_header(first_header: first_header_value, second_header: second_header_value)
+    end
+
+    context 'when the qurey parameters are nil' do
+      let(:first_header_value) { nil }
+      let(:second_header_value) { nil }
+
+      it 'requests to "GET header"' do
+        expect { api_request! }
+          .to request_to(:get, URI.join(endpoint, 'header'))
+          .with(headers: headers)
+      end
+    end
+
+    context 'when the qurey parameters is set' do
+      let(:first_header_value) { 'first' }
+      let(:second_header_value) { 'second' }
+
+      it 'requests to "GET header" with parameters' do
+        uri = URI.join(endpoint, 'header')
+        uri.query = URI.encode_www_form({ 'X-First-Header': 'first', 'X-Second-Header': 'second' })
+
+        expect { api_request! }
+          .to request_to(:get, uri)
+          .with(headers: headers)
+      end
+    end
+
+    describe 'error handling' do
+      let(:response_headers) do
+        {
+          'X-First-Header': first_header_value,
+          'X-Second-Header': second_header_value,
+        }.compact
+      end
+
+      context 'when the first header is invalid' do
+        let(:first_header_value) { 'this is invalid header value' }
+        let(:second_header_value) { nil }
+
+        it do
+          expect { api_request! }
+            .to be_handled_as_an_error(MyErrors::FirstHeaderIsInvalid)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+      context 'when the first header is zero' do
+        let(:first_header_value) { 0 }
+        let(:second_header_value) { nil }
+
+        it do
+          expect { api_request! }
+            .to be_handled_as_an_error(MyErrors::FirstHeaderIs00)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+      context 'when the first header is in 1xx' do
+        let(:first_header_value) { rand(100..199) }
+        let(:second_header_value) { nil }
+
+        it do
+          expect { api_request! }
+            .to be_handled_as_an_error(MyErrors::FirstHeaderIs1xx)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+      context 'when the first header is in 2xx and the second header is in 3xx' do
+        let(:first_header_value) { rand(200..299) }
+        let(:second_header_value) { rand(300..399) }
+
+        it do
+          expect { api_request! }
+            .to be_handled_as_an_error(MyErrors::MultipleHeaderIsInvalid)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+      context 'when the first header is in 2xx and the second header is out of 3xx' do
+        let(:first_header_value) { rand(200..299) }
+        let(:second_header_value) { 400 }
+
+        it do
+          expect { api_request! }
+            .not_to be_handled_as_an_error(MyApiClient::ClientError)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+      context 'when the first header is out of 2xx and the second header is in 3xx' do
+        let(:first_header_value) { 300 }
+        let(:second_header_value) { rand(300..399) }
+
+        it do
+          expect { api_request! }
+            .not_to be_handled_as_an_error(MyApiClient::ClientError)
+            .when_receive(headers: response_headers)
+        end
+      end
+
+
+      context 'when the first header is 30' do
+        let(:first_header_value) { 30 }
+        let(:second_header_value) { nil }
+
+        context 'with status code: 404' do
+          it do
+            expect { api_request! }
+              .to be_handled_as_an_error(MyErrors::FirstHeaderIs30WithNotFound)
+              .when_receive(headers: response_headers, status_code: 404)
+          end
+        end
+
+        context 'without status code: 404' do
+          it do
+            expect { api_request! }
+              .to be_handled_as_an_error(MyErrors::FirstHeaderIs30)
+              .when_receive(headers: response_headers, status_code: 200)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/integrations/api_clients/my_header_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_header_api_client_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require './example/api_clients/my_header_api_client'
+require 'my_api_client/rspec'
+
+RSpec.describe 'Integration test with My Header API', type: :integration do
+  describe 'GET header' do
+    shared_examples 'the API client' do
+      subject(:api_request) do
+        api_client.get_header(
+          first_header: first_header_value,
+          second_header: second_header_value
+        )
+      end
+
+      xcontext 'when the first header is invalid' do
+        let(:first_header_value) { 'this is invalid header value' }
+        let(:second_header_value) { nil }
+        it do 
+          expect { api_request }
+            .to raise_error(MyErrors::FirstHeaderIsInvalid)
+        end
+      end
+
+      xcontext 'when the first header is zero' do
+        let(:first_header_value) { 0 }
+        let(:second_header_value) { nil }
+        it do 
+          binding.pry
+          expect { api_request }
+            .to raise_error(MyErrors::FirstHeaderIs00)
+        end
+      end
+
+      context 'when the first header is in 1xx' do
+        let(:first_header_value) { rand(100..199) }
+        let(:second_header_value) { nil }
+        it do
+          expect { api_request }
+            .to raise_error(MyErrors::FirstHeaderIs1xx)
+        end
+      end
+
+    end
+
+    context 'with real connection' do
+      let(:api_client) { MyHeaderApiClient.new }
+
+      it_behaves_like 'the API client'
+    end
+
+    xcontext 'with stubbed API client' do
+      let(:api_client) { stub_api_client(MyHeaderApiClient, get_error: get_error) }
+
+      let(:get_error) do
+        lambda do |params|
+          exception =
+            case params[:code]
+            when 0      then MyErrors::ErrorCode00
+            when 10     then MyErrors::ErrorCode10
+            when 20..29 then MyErrors::ErrorCode2x
+            when 30     then MyErrors::ErrorCode30
+            else;            MyErrors::ErrorCodeOther
+            end
+          raise exception
+        end
+      end
+
+      it_behaves_like 'the API client'
+    end
+  end
+end

--- a/spec/integrations/api_clients/my_header_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_header_api_client_spec.rb
@@ -13,34 +13,25 @@ RSpec.describe 'Integration test with My Header API', type: :integration do
         )
       end
 
-      xcontext 'when the first header is invalid' do
+      context 'when the first header contains invalid' do
         let(:first_header_value) { 'this is invalid header value' }
         let(:second_header_value) { nil }
-        it do 
+
+        it do
           expect { api_request }
             .to raise_error(MyErrors::FirstHeaderIsInvalid)
         end
       end
 
-      xcontext 'when the first header is zero' do
-        let(:first_header_value) { 0 }
-        let(:second_header_value) { nil }
-        it do 
-          binding.pry
-          expect { api_request }
-            .to raise_error(MyErrors::FirstHeaderIs00)
-        end
-      end
+      context 'when the first header contains unknown and the second header contains error' do
+        let(:first_header_value) { 'this header value is unknown' }
+        let(:second_header_value) { 'error has occurred' }
 
-      context 'when the first header is in 1xx' do
-        let(:first_header_value) { rand(100..199) }
-        let(:second_header_value) { nil }
         it do
           expect { api_request }
-            .to raise_error(MyErrors::FirstHeaderIs1xx)
+            .to raise_error(MyErrors::MultipleHeaderIsInvalid)
         end
       end
-
     end
 
     context 'with real connection' do
@@ -49,20 +40,17 @@ RSpec.describe 'Integration test with My Header API', type: :integration do
       it_behaves_like 'the API client'
     end
 
-    xcontext 'with stubbed API client' do
-      let(:api_client) { stub_api_client(MyHeaderApiClient, get_error: get_error) }
+    context 'with stubbed API client' do
+      let(:api_client) { stub_api_client(MyHeaderApiClient, get_header: get_header) }
 
-      let(:get_error) do
+      let(:get_header) do
         lambda do |params|
-          exception =
-            case params[:code]
-            when 0      then MyErrors::ErrorCode00
-            when 10     then MyErrors::ErrorCode10
-            when 20..29 then MyErrors::ErrorCode2x
-            when 30     then MyErrors::ErrorCode30
-            else;            MyErrors::ErrorCodeOther
-            end
-          raise exception
+          if /unknown/.match?(params[:first_header]) &&
+             /error/.match?(params[:second_header])
+            raise MyErrors::MultipleHeaderIsInvalid
+          elsif /invalid/.match?(params[:first_header])
+            raise MyErrors::FirstHeaderIsInvalid
+          end
         end
       end
 

--- a/spec/lib/my_api_client/error_handling/generator_spec.rb
+++ b/spec/lib/my_api_client/error_handling/generator_spec.rb
@@ -401,24 +401,6 @@ RSpec.describe MyApiClient::ErrorHandling::Generator do
         end
       end
 
-      context 'with forbid_nil' do
-        let(:matcher_options) do
-          { headers: :forbid_nil }
-        end
-
-        context 'when matcher options match the HTTP response' do
-          let(:response_headers) { nil }
-
-          it_behaves_like 'an error was detected'
-        end
-
-        context 'when matcher options does NOT match the HTTP response' do
-          let(:response_headers) { '' }
-
-          it_behaves_like 'no errors were detected'
-        end
-      end
-
       context 'with unexpected operator' do
         let(:matcher_options) do
           { headers: {


### PR DESCRIPTION
resolves #789

To make it support the header error handling for `error_handling`.

For example

```
error_handling headers: { 'www-authenticate': /invalid token/ }, with: :my_error_handling
```
