### PR TITLE
Fix error that generating api client failed on Rails 7

### DIFF
--- a/lib/generators/generator_helper.rb
+++ b/lib/generators/generator_helper.rb
@@ -3,6 +3,10 @@
 module MyApiClient
   # The helper module for source generators
   module GeneratorHelper
+    def self.included(base)
+      base.include(Rails::Generators::ResourceHelpers)
+    end
+
     def yeild_request_arguments
       requests.each do |request|
         http_method, pathname = request.split(':')


### PR DESCRIPTION
`my_api_client` generator does not work on Rails7.

> $ rails g api_client path/to/resource get:path/to/resource --endpoint https://example.com/
> Running via Spring preloader in process 90
> /usr/local/bundle/ruby/3.0.0/gems/railties-7.0.4/lib/rails/generators/named_base.rb:130:in `route_url': undefined local variable or method `controller_class_path' for #<Rails::ApiClientGenerator:0x0000ffff751ae238 @inside_template=nil, @behavior=:invoke, @_invocations={Rails::ApiClientGenerator=>["check_class_collision", "generate_root_class", "generate_api_client"]}, @_initializer=[["path/to/resource", "get:path/to/resource"], ["--endpoint", "https://example.com/"], {:behavior=>:invoke, :destination_root=>#<Pathname:/app>, :shell=>#<Thor::Shell::Color:0x0000ffff751ae4b8 @base=#<Rails::ApiClientGenerator:0x0000ffff751ae238 ...>, @mute=false, @padding=0, @always_force=false>}], @options={"skip_namespace"=>false, "skip_collision_check"=>false, "endpoint"=>"https://example.com/", "test_framework"=>:rspec}, @requests=["get:path/to/resource"], @name="path/to/resource", @args=[], @shell=#<Thor::Shell::Color:0x0000ffff751ae4b8 @base=#<Rails::ApiClientGenerator:0x0000ffff751ae238 ...>, @mute=false, @padding=0, @always_force=false>, @destination_stack=["/app"], @indentation=0, @class_path=["path", "to"], @file_name="resource"> (NameError)

In Rails 7, the `#route_url` method requires `#controller_class_path` definition. The `#controller_class_path` is defined on `Rails::Generators::ResourceHelpers`. 

Therefore, `my_api_client` should include `Rails::Generators::ResourceHelpers` for each generator classes.