### PR TITLE
Add ` #_{http_method}` method to retrieve sawyer-response

### DIFF
--- a/lib/my_api_client/request/basic.rb
+++ b/lib/my_api_client/request/basic.rb
@@ -22,8 +22,23 @@ module MyApiClient
           # @return [Sawyer::Resource]
           #   Response body instance.
           def #{http_method}(pathname, headers: nil, query: nil, body: nil)
-            response = call(:_request_with_relative_uri, :#{http_method}, pathname, headers, query, body)
-            response.data
+            _#{http_method}(pathname, headers: headers, query: query, body: body).data
+          end
+          # Executes HTTP request with #{http_method.upcase} method
+          #
+          # @param pathname [String]
+          #   Pathname of the request target URL.
+          #   It's joined with the defined by `endpoint`.
+          # @param headers [Hash, nil]
+          #   Request headers.
+          # @param query [Hash, nil]
+          #   Query string.
+          # @param body [Hash, nil]
+          #   Request body. You should not specify it when use GET method.
+          # @return [Sawyer::Response]
+          #   Sawyer Response instance.
+          def _#{http_method}(pathname, headers: nil, query: nil, body: nil)
+            call(:_request_with_relative_uri, :#{http_method}, pathname, headers, query, body)
           end
         METHOD
       end

--- a/spec/lib/my_api_client/request/basic_spec.rb
+++ b/spec/lib/my_api_client/request/basic_spec.rb
@@ -2,35 +2,35 @@
 
 RSpec.describe MyApiClient::Request::Basic do
   described_class::HTTP_METHODS.each do |http_method|
+    let(:mock_class) do
+      Class.new do
+        include MyApiClient::Request::Basic
+        include MyApiClient::Exceptions
+
+        def _request_with_relative_uri(http_method, pathname, headers, query, body); end
+      end
+    end
+
+    let(:instance) { mock_class.new }
+    let(:pathname) { 'path/to/resource' }
+    let(:headers) { { 'Content-Type': 'application/json;charset=UTF-8' } }
+    let(:response) { instance_double(Sawyer::Response, data: resource) }
+    let(:resource) { instance_double(Sawyer::Resource) }
+
+    if http_method == :get
+      let(:query) { { key: 'value' } }
+      let(:body) { nil }
+    else
+      let(:query) { nil }
+      let(:body) { { name: 'John', birth: Date.today } }
+    end
+
+    before { allow(instance).to receive(:_request_with_relative_uri).and_return(response) }
+
     describe "##{http_method}" do
       subject(:execute) do
         instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
       end
-
-      let(:mock_class) do
-        Class.new do
-          include MyApiClient::Request::Basic
-          include MyApiClient::Exceptions
-
-          def _request_with_relative_uri(http_method, pathname, headers, query, body); end
-        end
-      end
-
-      let(:instance) { mock_class.new }
-      let(:pathname) { 'path/to/resource' }
-      let(:headers) { { 'Content-Type': 'application/json;charset=UTF-8' } }
-      let(:response) { instance_double(Sawyer::Response, data: resource) }
-      let(:resource) { instance_double(Sawyer::Resource) }
-
-      if http_method == :get
-        let(:query) { { key: 'value' } }
-        let(:body) { nil }
-      else
-        let(:query) { nil }
-        let(:body) { { name: 'John', birth: Date.today } }
-      end
-
-      before { allow(instance).to receive(:_request_with_relative_uri).and_return(response) }
 
       it 'calls the request method with relative URL' do
         execute
@@ -40,6 +40,23 @@ RSpec.describe MyApiClient::Request::Basic do
 
       it 'returns a response body object' do
         expect(execute).to eq resource
+      end
+    end
+
+    describe "#_#{http_method}" do
+      subject(:execute) do
+        instance.public_send("_#{http_method}", pathname, headers: headers, query: query,
+                                                          body: body)
+      end
+
+      it 'calls the request method with relative URL' do
+        execute
+        expect(instance).to have_received(:_request_with_relative_uri)
+          .with(http_method, pathname, headers, query, body)
+      end
+
+      it 'returns a sawyer-response object' do
+        expect(execute).to eq response
       end
     end
   end


### PR DESCRIPTION
## Why

It is unable to retrieve the response header when using this library to make HTTP requests.
The library allows me to obtain the response body successfully, but retrieving the response header was not straightforward.

## How

Add `#_get` `#_post` `#_put` `#_patch` `#_delete` method that returns the entire response object as it is received.
This method should provide a comprehensive solution for obtaining both the response body and the response header when making HTTP requests using this gem.

Please review the changes in the pull request and let me know if any further modifications or adjustments are needed.
Thank you!
