### PR TITLE
Add yield to retrieve sawyer response

### DIFF
--- a/lib/my_api_client/request/basic.rb
+++ b/lib/my_api_client/request/basic.rb
@@ -20,10 +20,18 @@ module MyApiClient
           # @param body [Hash, nil]
           #   Request body. You should not specify it when use GET method.
           # @return [Sawyer::Resource]
-          #   Response body instance.
+          #   Response body instance if the block is not given.
+          # @yield
+          #   Process the response body with the given block.
+          # @yieldparam response [Sawyer::Response]
+          #   Response instance.
+          # @yieldreturn [<T>]
+          #   The block result.
+          # @return [<T>]
+          #   Whatever the block returns if the block is given.
           def #{http_method}(pathname, headers: nil, query: nil, body: nil)
             response = call(:_request_with_relative_uri, :#{http_method}, pathname, headers, query, body)
-            response.data
+            block_given? ? yield(response) : response.data
           end
         METHOD
       end

--- a/lib/my_api_client/request/pagination.rb
+++ b/lib/my_api_client/request/pagination.rb
@@ -18,12 +18,19 @@ module MyApiClient
       # @param body [Hash, nil]
       #   Request body. You should not specify it when use GET method.
       # @return [Enumerator::Lazy]
-      #   Yields the pagination API response.
+      #   Yields the pagination API response if the block is given.
+      #   Whatever the block returns if the block is given.
+      # @yield
+      #   Process the response body with the given block.
+      # @yieldparam response [Sawyer::Response]
+      #   Response instance.
+      # @yieldreturn [<T>]
+      #   The block result.
       def pageable_get(pathname, paging:, headers: nil, query: nil)
         Enumerator.new do |y|
           response = call(:_request_with_relative_uri, :get, pathname, headers, query, nil)
           loop do
-            y << response.data
+            y << (block_given? ? yield(response) : response.data)
 
             next_uri = JsonPath.new(paging).first(response.body)
             break if next_uri.blank?

--- a/spec/example/api_clients/my_header_api_client_spec.rb
+++ b/spec/example/api_clients/my_header_api_client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MyHeaderApiClient, type: :api_client do
       api_client.get_header(first_header: first_header_value, second_header: second_header_value)
     end
 
-    context 'when the qurey parameters are nil' do
+    context 'when the query parameters are nil' do
       let(:first_header_value) { nil }
       let(:second_header_value) { nil }
 
@@ -26,7 +26,7 @@ RSpec.describe MyHeaderApiClient, type: :api_client do
       end
     end
 
-    context 'when the qurey parameters is set' do
+    context 'when the query parameters is set' do
       let(:first_header_value) { 'first' }
       let(:second_header_value) { 'second' }
 

--- a/spec/lib/my_api_client/request/basic_spec.rb
+++ b/spec/lib/my_api_client/request/basic_spec.rb
@@ -3,10 +3,6 @@
 RSpec.describe MyApiClient::Request::Basic do
   described_class::HTTP_METHODS.each do |http_method|
     describe "##{http_method}" do
-      subject(:execute) do
-        instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
-      end
-
       let(:mock_class) do
         Class.new do
           include MyApiClient::Request::Basic
@@ -32,14 +28,44 @@ RSpec.describe MyApiClient::Request::Basic do
 
       before { allow(instance).to receive(:_request_with_relative_uri).and_return(response) }
 
-      it 'calls the request method with relative URL' do
-        execute
-        expect(instance).to have_received(:_request_with_relative_uri)
-          .with(http_method, pathname, headers, query, body)
+      context 'when the block is not given' do
+        subject(:execute) do
+          instance.public_send(http_method, pathname, headers: headers, query: query, body: body)
+        end
+
+        it 'calls the request method with relative URL' do
+          execute
+          expect(instance).to have_received(:_request_with_relative_uri)
+            .with(http_method, pathname, headers, query, body)
+        end
+
+        it 'returns a response body object' do
+          expect(execute).to eq resource
+        end
       end
 
-      it 'returns a response body object' do
-        expect(execute).to eq resource
+      context 'when the block is given' do
+        subject(:execute) do
+          instance.public_send(
+            http_method,
+            pathname,
+            headers: headers,
+            query: query,
+            body: body
+          ) do |response|
+            response
+          end
+        end
+
+        it 'calls the request method with relative URL' do
+          execute
+          expect(instance).to have_received(:_request_with_relative_uri)
+            .with(http_method, pathname, headers, query, body)
+        end
+
+        it 'passes the sawyer response to the block parameter and returns the block result' do
+          expect(execute).to eq response
+        end
       end
     end
   end

--- a/spec/lib/my_api_client/request/pagination_spec.rb
+++ b/spec/lib/my_api_client/request/pagination_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe MyApiClient::Request::Pagination do
   include MyApiClient::MatcherHelper
 
   describe '#pageable_get' do
-    subject :pageable_get do
-      instance.pageable_get(
-        'pages/1', paging: '$.next', headers: headers, query: query
-      )
-    end
-
     let(:mock_class) do
       Class.new do
         include MyApiClient::Request::Pagination
@@ -60,24 +54,62 @@ RSpec.describe MyApiClient::Request::Pagination do
         .and_return(second_response, third_response)
     end
 
-    it { is_expected.to be_a Enumerator::Lazy }
+    context 'when the block is not given' do
+      subject :pageable_get do
+        instance.pageable_get(
+          'pages/1', paging: '$.next', headers: headers, query: query
+        )
+      end
 
-    it 'executes HTTP requests sequentially to the pagination links' do
-      pageable_get.to_a
-      expect(instance).to have_received(:_request_with_relative_uri)
-        .with(:get, 'pages/1', headers, query, nil).ordered
-      expect(instance).to have_received(:_request_with_absolute_uri)
-        .with(:get, 'https://example.com/pages/2', headers, nil).ordered
-      expect(instance).to have_received(:_request_with_absolute_uri)
-        .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      it { is_expected.to be_a Enumerator::Lazy }
+
+      it 'executes HTTP requests sequentially to the pagination links' do
+        pageable_get.to_a
+        expect(instance).to have_received(:_request_with_relative_uri)
+          .with(:get, 'pages/1', headers, query, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/2', headers, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      end
+
+      it 'yields the pagination API response' do
+        expect { |b| pageable_get.each(&b) }.to yield_successive_args(
+          first_response.data,
+          second_response.data,
+          third_response.data
+        )
+      end
     end
 
-    it 'yields the pagination API response' do
-      expect { |b| pageable_get.each(&b) }.to yield_successive_args(
-        first_response.data,
-        second_response.data,
-        third_response.data
-      )
+    context 'when the block is given' do
+      subject :pageable_get do
+        instance.pageable_get(
+          'pages/1', paging: '$.next', headers: headers, query: query
+        ) do |response|
+          response
+        end
+      end
+
+      it { is_expected.to be_a Enumerator::Lazy }
+
+      it 'executes HTTP requests sequentially to the pagination links' do
+        pageable_get.to_a
+        expect(instance).to have_received(:_request_with_relative_uri)
+          .with(:get, 'pages/1', headers, query, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/2', headers, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      end
+
+      it 'passes the sawyer response to the block and yields the pagination API response' do
+        expect { |b| pageable_get.each(&b) }.to yield_successive_args(
+          first_response,
+          second_response,
+          third_response
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

> see: https://github.com/ryz310/my_api_client/pull/943#pullrequestreview-1714097637 and it would be closed by this PR
> But I prefer the following block style to the #_{http_method} style

It is unable to retrieve the response header when using this library to make HTTP requests.
The library allows me to obtain the response body successfully, but retrieving the response header was not straightforward.



## How

Add block style that the method yields the entire response object as it is received.
This method should provide a comprehensive solution for obtaining both the response body and the response header when making HTTP requests using this gem.

This PR makes following methods to support block style:
- `#get`, `#post`, `#put`, `#patch`, `#delete`
- `#pget`, `#pageable_get`

Please review the changes in the pull request and let me know if any further modifications or adjustments are needed.
Thank you!
