### PR TITLE
Enable Dynamic URL Generation for `#pageable_get` via `Proc` Objects

### DIFF
--- a/example/api_clients/my_pagination_api_client.rb
+++ b/example/api_clients/my_pagination_api_client.rb
@@ -5,9 +5,18 @@ require_relative 'application_api_client'
 # An usage example of the `my_api_client`.
 # See also: my_api/app/controllers/pagination_controller.rb
 class MyPaginationApiClient < ApplicationApiClient
+  # Paging with JSONPath
   # GET pagination?page=1
-  def pagination
-    pget 'pagination', paging: '$.links.next', headers: headers, query: { page: 1 }
+  def paging_with_jsonpath
+    pget 'pagination', headers: headers, query: { page: 1 }, paging: '$.links.next'
+  end
+
+  # Paging with Proc
+  # GET pagination?page=1
+  def paging_with_proc
+    pget 'pagination', headers: headers, query: { page: 1 }, paging: lambda { |response|
+      response.data.links.next
+    }
   end
 
   private

--- a/lib/my_api_client/rspec/stub.rb
+++ b/lib/my_api_client/rspec/stub.rb
@@ -144,6 +144,7 @@ module MyApiClient
         status: status_code.presence || 400,
         headers: {},
         data: stub_as_resource(params),
+        body: params.to_json,
         timing: 0.123
       )
     end

--- a/spec/example/api_clients/my_pagination_api_client_spec.rb
+++ b/spec/example/api_clients/my_pagination_api_client_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe MyPaginationApiClient, type: :api_client do
     { 'Content-Type': 'application/json;charset=UTF-8' }
   end
 
-  describe '#pagination' do
-    subject(:api_request!) { api_client.pagination.first }
-
+  shared_examples 'an API client' do
     it do
       expect { api_request! }
         .to request_to(:get, URI.join(endpoint, 'pagination'))
@@ -38,5 +36,17 @@ RSpec.describe MyPaginationApiClient, type: :api_client do
           .when_receive(status_code: 500)
       end
     end
+  end
+
+  describe '#paging_with_jsonpath' do
+    subject(:api_request!) { api_client.paging_with_jsonpath.first }
+
+    it_behaves_like 'an API client'
+  end
+
+  describe '#paging_with_proc' do
+    subject(:api_request!) { api_client.paging_with_proc.first }
+
+    it_behaves_like 'an API client'
   end
 end

--- a/spec/integrations/api_clients/my_pagination_api_client_spec.rb
+++ b/spec/integrations/api_clients/my_pagination_api_client_spec.rb
@@ -5,35 +5,74 @@ require 'my_api_client/rspec'
 
 RSpec.describe 'Integration test with My Pagination API', type: :integration do
   describe 'GET pagination' do
-    shared_examples 'the API client' do
-      it 'returns an array of posts ordered by id' do
-        api_client.pagination.each.with_index(1) do |response, idx|
-          expect(response.page).to eq idx
+    describe 'paging with JSONPath' do
+      subject(:request_with_pagination) { api_client.paging_with_jsonpath.to_a }
+
+      context 'with real connection' do
+        let(:api_client) { MyPaginationApiClient.new }
+
+        it 'returns an array of posts ordered by id' do
+          request_with_pagination.each.with_index(1) do |response, idx|
+            expect(response.page).to eq idx
+          end
+        end
+      end
+
+      context 'with stubbed API client' do
+        let(:api_client) do
+          stub_api_client(
+            MyPaginationApiClient,
+            paging_with_jsonpath: {
+              pageable: [
+                { page: 1 },
+                { page: 2 },
+                { page: 3 },
+              ],
+            }
+          )
+        end
+
+        it 'returns an array of posts ordered by id' do
+          request_with_pagination.each.with_index(1) do |response, idx|
+            expect(response.page).to eq idx
+          end
         end
       end
     end
 
-    context 'with real connection' do
-      let(:api_client) { MyPaginationApiClient.new }
+    describe 'paging with Proc' do
+      subject(:request_with_pagination) { api_client.paging_with_proc.to_a }
 
-      it_behaves_like 'the API client'
-    end
+      context 'with real connection' do
+        let(:api_client) { MyPaginationApiClient.new }
 
-    context 'with stubbed API client' do
-      let(:api_client) do
-        stub_api_client(
-          MyPaginationApiClient,
-          pagination: {
-            pageable: [
-              { page: 1 },
-              { page: 2 },
-              { page: 3 },
-            ],
-          }
-        )
+        it 'returns an array of posts ordered by id' do
+          request_with_pagination.each.with_index(1) do |response, idx|
+            expect(response.page).to eq idx
+          end
+        end
       end
 
-      it_behaves_like 'the API client'
+      context 'with stubbed API client' do
+        let(:api_client) do
+          stub_api_client(
+            MyPaginationApiClient,
+            paging_with_proc: {
+              pageable: [
+                { page: 1 },
+                { page: 2 },
+                { page: 3 },
+              ],
+            }
+          )
+        end
+
+        it 'returns an array of posts ordered by id' do
+          request_with_pagination.each.with_index(1) do |response, idx|
+            expect(response.page).to eq idx
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/my_api_client/request/pagination_spec.rb
+++ b/spec/lib/my_api_client/request/pagination_spec.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-require 'my_api_client/rspec/matcher_helper'
+require 'my_api_client/rspec/stub'
 
 RSpec.describe MyApiClient::Request::Pagination do
-  include MyApiClient::MatcherHelper
+  include MyApiClient::Stub
 
   describe '#pageable_get' do
-    subject :pageable_get do
-      instance.pageable_get(
-        'pages/1', paging: '$.next', headers: headers, query: query
-      )
-    end
-
     let(:mock_class) do
       Class.new do
         include MyApiClient::Request::Pagination
@@ -28,28 +22,31 @@ RSpec.describe MyApiClient::Request::Pagination do
     let(:query) { { key: 'value' } }
 
     let(:first_response) do
-      dummy_response(
-        body: {
+      stub_as_response(
+        {
           page: 1,
           next: 'https://example.com/pages/2',
-        }.to_json
+        },
+        200
       )
     end
 
     let(:second_response) do
-      dummy_response(
-        body: {
+      stub_as_response(
+        {
           page: 2,
           next: 'https://example.com/pages/3',
-        }.to_json
+        },
+        200
       )
     end
 
     let(:third_response) do
-      dummy_response(
-        body: {
+      stub_as_response(
+        {
           page: 3,
-        }.to_json
+        },
+        200
       )
     end
 
@@ -60,24 +57,60 @@ RSpec.describe MyApiClient::Request::Pagination do
         .and_return(second_response, third_response)
     end
 
-    it { is_expected.to be_a Enumerator::Lazy }
+    describe 'paging with JSONPath' do
+      subject(:pageable_get) do
+        instance.pageable_get(
+          'pages/1', headers: headers, query: query, paging: '$.next'
+        )
+      end
 
-    it 'executes HTTP requests sequentially to the pagination links' do
-      pageable_get.to_a
-      expect(instance).to have_received(:_request_with_relative_uri)
-        .with(:get, 'pages/1', headers, query, nil).ordered
-      expect(instance).to have_received(:_request_with_absolute_uri)
-        .with(:get, 'https://example.com/pages/2', headers, nil).ordered
-      expect(instance).to have_received(:_request_with_absolute_uri)
-        .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      it { is_expected.to be_a Enumerator::Lazy }
+
+      it 'executes HTTP requests sequentially to the pagination links' do
+        pageable_get.to_a
+        expect(instance).to have_received(:_request_with_relative_uri)
+          .with(:get, 'pages/1', headers, query, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/2', headers, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      end
+
+      it 'yields the pagination API response' do
+        expect { |b| pageable_get.each(&b) }.to yield_successive_args(
+          first_response.data,
+          second_response.data,
+          third_response.data
+        )
+      end
     end
 
-    it 'yields the pagination API response' do
-      expect { |b| pageable_get.each(&b) }.to yield_successive_args(
-        first_response.data,
-        second_response.data,
-        third_response.data
-      )
+    describe 'paging with Proc' do
+      subject(:pageable_get) do
+        instance.pageable_get(
+          'pages/1', headers: headers, query: query, paging: ->(response) { response.data.next }
+        )
+      end
+
+      it { is_expected.to be_a Enumerator::Lazy }
+
+      it 'executes HTTP requests sequentially to the pagination links' do
+        pageable_get.to_a
+        expect(instance).to have_received(:_request_with_relative_uri)
+          .with(:get, 'pages/1', headers, query, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/2', headers, nil).ordered
+        expect(instance).to have_received(:_request_with_absolute_uri)
+          .with(:get, 'https://example.com/pages/3', headers, nil).ordered
+      end
+
+      it 'yields the pagination API response' do
+        expect { |b| pageable_get.each(&b) }.to yield_successive_args(
+          first_response.data,
+          second_response.data,
+          third_response.data
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
#### Summary

This Pull Request introduces an enhancement to the `#pageable_get` method in our Ruby library. It enables the use of a `Proc` object for the `paging` option, allowing more dynamic and flexible generation of request URLs based on the response body.

#### Background

Previously, the `paging` option in the `#pageable_get` method was limited to specifying URLs using JSONPath. This approach was effective but had a limitation: it could not handle cases where the URL provided in the response body was not a full path. This limitation could hinder the method's utility in scenarios where the API responses include relative URLs or require more complex URL construction based on the response.

#### Changes

The proposed change allows the `paging` option to accept a `Proc` object. This enhancement provides the following benefits:

1. **Flexibility**: Users can now define custom logic to generate the next request URL dynamically. This is particularly useful when dealing with APIs that return relative URLs or require additional processing to construct the next URL.
2. **Enhanced Control**: By using a `Proc`, users gain finer control over the URL generation process, allowing for more complex scenarios and efficient handling of API responses.
3. **Backward Compatibility**: The existing functionality using JSONPath remains intact, ensuring that current implementations are not affected.

#### Implementation Details

With this update, when a `Proc` is provided as the `paging` option, it will be called with the `Sawyer::Response` object as its argument. This allows the `Proc` to access the entire response body and headers, enabling it to generate the next URL based on any aspect of the response.

#### Example Usage

```ruby
# Example of using a Proc with pageable_get
pget 'api/example', headers:, query:, paging: ->(response) {
  # Custom logic to generate the next URL
}
```

#### Conclusion

This enhancement to the `#pageable_get` method significantly increases its versatility and applicability to a broader range of API interactions. By allowing dynamic URL generation through a `Proc`, we can accommodate a wider variety of API response patterns, making our library more robust and flexible for users.

