### PR TITLE
 Fix handling when the error changes after a retry

### DIFF
--- a/lib/my_api_client/exceptions.rb
+++ b/lib/my_api_client/exceptions.rb
@@ -55,5 +55,16 @@ module MyApiClient
       @retry_count += 1
       @retry_result = call(*args)
     end
+
+    # call the handler for exception
+    #
+    # @note
+    #   To avoid handling the exception of the retry origin on the second and subsequent retries,
+    #   make exception.cause visited.
+    # @override ActiveSupport::Rescuable#rescue_with_handler
+    # @param exception [Exception] Target exception
+    def rescue_with_handler(exception)
+      self.class.rescue_with_handler(exception, object: self, visited_exceptions: [exception.cause])
+    end
   end
 end


### PR DESCRIPTION
## Motivation / Background

This gem utilizes retry_on with ActiveSupport::Rescuable for implementation, but the behavior of `ActiveSupport::Rescuable.rescue_with_handler` has changed since ActiveSupport v5.2.

Since ActiveSupport 5.2, if no handler exists for the exception passed as an argument, it searches for a handler attached to the `#cause` of that exception.

https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/rescuable.rb#L88-L101

Therefore, even when the exception changes after being retried due to a retryable exception, 
it continues to be processed as a retryable exception because it searches for a handler attached to the `#cause` of the exception.

e.g.

```rb
class Example
  class RetriableError < StandardError; end
  class OtherError < StandardError; end

  include MyApiClient::Exceptions

  retry_on RetriableError, wait: 0.seconds, attempts: 2

  private

  def execute
    puts 'execute'
    unless @first_executed
      @first_executed = true
      raise RetriableError
    else
      raise OtherError
    end
  end
end

instance.call(:execute) # => 1. raised RetriableError, and retry
                        # => 2. raised OtherError, handler not found. but searches for a handler of `Exception#cause` that is RetryableError
                        # => 3. continues retry 

```

## Detail

Override ActiveSupport::Rescuable.rescue_with_handler and pass Exception#cause to visited_exceptions to treat it as a "handled" exception.

