### PR TITLE
Support lazy evaluation for request headers and body parameters

### DIFF
--- a/lib/my_api_client/params/request.rb
+++ b/lib/my_api_client/params/request.rb
@@ -10,13 +10,13 @@ module MyApiClient
       #
       # @param method [Symbol] describe_method_here
       # @param uri [URI] describe_uri_here
-      # @param headers [Hash, nil] describe_headers_here
-      # @param body [Hash, nil] describe_body_here
+      # @param headers [Hash, Proc<Hash>, nil] describe_headers_here
+      # @param body [Hash, Proc<Hash>, nil] describe_body_here
       def initialize(method, uri, headers, body)
         @method = method
         @uri = uri
-        @headers = headers
-        @body = body
+        @headers = headers.is_a?(Proc) ? headers.call : headers
+        @body = body.is_a?(Proc) ? body.call : body
       end
 
       # Description of #to_sawyer_args

--- a/lib/my_api_client/request.rb
+++ b/lib/my_api_client/request.rb
@@ -15,11 +15,11 @@ module MyApiClient
     # @param pathname [String]
     #   Pathname of the request target URL.
     #   It's joined with the defined by `endpoint`.
-    # @param headers [Hash, nil]
+    # @param headers [Hash, Proc<Hash>, nil]
     #   Request headers.
     # @param query [Hash, nil]
     #   Query string.
-    # @param body [Hash, nil]
+    # @param body [Hash, Proc<Hash>, nil]
     #   Request body.
     # @return [Sawyer::Response]
     #   Response instance.
@@ -35,9 +35,9 @@ module MyApiClient
     #   HTTP method. e.g. `:get`, `:post`, `:put`, `:patch` and `:delete`.
     # @param uri [URI]
     #   Request target URI including query strings.
-    # @param headers [Hash, nil]
+    # @param headers [Hash, Proc<Hash>, nil]
     #   Request headers.
-    # @param body [Hash, nil]
+    # @param body [Hash, Proc<Hash>, nil]
     #   Request body.
     # @return [Sawyer::Response]
     #   Response instance.

--- a/lib/my_api_client/request/basic.rb
+++ b/lib/my_api_client/request/basic.rb
@@ -13,11 +13,11 @@ module MyApiClient
           # @param pathname [String]
           #   Pathname of the request target URL.
           #   It's joined with the defined by `endpoint`.
-          # @param headers [Hash, nil]
+          # @param headers [Hash, Proc<Hash>, nil]
           #   Request headers.
           # @param query [Hash, nil]
           #   Query string.
-          # @param body [Hash, nil]
+          # @param body [Hash, Proc<Hash>, nil]
           #   Request body. You should not specify it when use GET method.
           # @return [Sawyer::Resource]
           #   Response body instance if the block is not given.

--- a/lib/my_api_client/request/pagination.rb
+++ b/lib/my_api_client/request/pagination.rb
@@ -11,12 +11,10 @@ module MyApiClient
       #   Pathname of the request target URL. It's joined with the defined by `endpoint`.
       # @param paging [String, Proc]
       #   Specify the pagination link path included in the response body as JsonPath expression
-      # @param headers [Hash, nil]
+      # @param headers [Hash, Proc<Hash>, nil]
       #   Request headers.
       # @param query [Hash, nil]
       #   Query string.
-      # @param body [Hash, nil]
-      #   Request body. You should not specify it when use GET method.
       # @return [Enumerator::Lazy]
       #   Yields the pagination API response.
       def pageable_get(pathname, paging:, headers: nil, query: nil)

--- a/spec/lib/my_api_client/params/request_spec.rb
+++ b/spec/lib/my_api_client/params/request_spec.rb
@@ -4,52 +4,121 @@ RSpec.describe MyApiClient::Params::Request do
   let(:instance) { described_class.new(method, uri, headers, body) }
   let(:method) { :get }
   let(:uri) { URI.parse 'https://example.com/path/to/resource?key=value' }
-  let(:headers) { { 'Content-Type': 'application/json; charset=utf-8' } }
-  let(:body) { nil }
 
-  describe '#to_sawyer_args' do
-    it 'returns value formatted for arguments of Sawyer::Agent#call' do
-      expect(instance.to_sawyer_args).to eq [
-        :get,
-        'https://example.com/path/to/resource?key=value',
-        nil,
-        { headers: { 'Content-Type': 'application/json; charset=utf-8' } },
-      ]
-    end
-  end
-
-  describe '#metadata' do
-    context 'when body parameter is blank' do
-      it 'returns hashed parameters which omitted body parameter' do
-        expect(instance.metadata).to eq(
-          line: 'GET https://example.com/path/to/resource?key=value',
-          headers: { 'Content-Type': 'application/json; charset=utf-8' }
-        )
-      end
-    end
-
-    context 'when query parameter is blank' do
-      let(:method) { :post }
-      let(:uri) { URI.parse 'https://example.com/path/to/resource' }
+  describe 'headers and body' do
+    context 'with Hash' do
+      let(:headers) { { 'Content-Type': 'application/json; charset=utf-8' } }
       let(:body) { { username: 'John Smith' } }
 
-      it 'returns hashed parameters which omitted query parameter' do
-        expect(instance.metadata).to eq(
-          line: 'POST https://example.com/path/to/resource',
-          headers: { 'Content-Type': 'application/json; charset=utf-8' },
-          body: { username: 'John Smith' }
-        )
+      describe '#to_sawyer_args' do
+        it 'returns value formatted for arguments of Sawyer::Agent#call' do
+          expect(instance.to_sawyer_args).to eq [
+            :get,
+            'https://example.com/path/to/resource?key=value',
+            { username: 'John Smith' },
+            { headers: { 'Content-Type': 'application/json; charset=utf-8' } },
+          ]
+        end
+      end
+
+      describe '#metadata' do
+        context 'when body parameter is blank' do
+          let(:body) { nil }
+
+          it 'returns hashed parameters which omitted body parameter' do
+            expect(instance.metadata).to eq(
+              line: 'GET https://example.com/path/to/resource?key=value',
+              headers: { 'Content-Type': 'application/json; charset=utf-8' }
+            )
+          end
+        end
+
+        context 'when query parameter is blank' do
+          let(:method) { :post }
+          let(:uri) { URI.parse 'https://example.com/path/to/resource' }
+
+          it 'returns hashed parameters which omitted query parameter' do
+            expect(instance.metadata).to eq(
+              line: 'POST https://example.com/path/to/resource',
+              headers: { 'Content-Type': 'application/json; charset=utf-8' },
+              body: { username: 'John Smith' }
+            )
+          end
+        end
+      end
+
+      describe '#inspect' do
+        it 'returns contents as string for to be readable for human' do
+          expect(instance.inspect)
+            .to eq '{:method=>:get, ' \
+                   ':uri=>"https://example.com/path/to/resource?key=value", ' \
+                   ':headers=>{:"Content-Type"=>"application/json; charset=utf-8"}, ' \
+                   ':body=>{:username=>"John Smith"}}'
+        end
       end
     end
-  end
 
-  describe '#inspect' do
-    it 'returns contents as string for to be readable for human' do
-      expect(instance.inspect)
-        .to eq '{:method=>:get, ' \
-               ':uri=>"https://example.com/path/to/resource?key=value", ' \
-               ':headers=>{:"Content-Type"=>"application/json; charset=utf-8"}, ' \
-               ':body=>nil}'
+    context 'with Proc' do
+      let(:data_array) { %w[request_id user_name] }
+
+      let(:headers) do
+        lambda {
+          { 'X-Request-Id': data_array.shift }
+        }
+      end
+
+      let(:body) do
+        lambda {
+          { username: data_array.shift }
+        }
+      end
+
+      describe '#to_sawyer_args' do
+        it 'returns value formatted for arguments of Sawyer::Agent#call' do
+          expect(instance.to_sawyer_args).to eq [
+            :get,
+            'https://example.com/path/to/resource?key=value',
+            { username: 'user_name' },
+            { headers: { 'X-Request-Id': 'request_id' } },
+          ]
+        end
+      end
+
+      describe '#metadata' do
+        context 'when body parameter is blank' do
+          let(:body) { nil }
+
+          it 'returns hashed parameters which omitted body parameter' do
+            expect(instance.metadata).to eq(
+              line: 'GET https://example.com/path/to/resource?key=value',
+              headers: { 'X-Request-Id': 'request_id' }
+            )
+          end
+        end
+
+        context 'when query parameter is blank' do
+          let(:method) { :post }
+          let(:uri) { URI.parse 'https://example.com/path/to/resource' }
+
+          it 'returns hashed parameters which omitted query parameter' do
+            expect(instance.metadata).to eq(
+              line: 'POST https://example.com/path/to/resource',
+              headers: { 'X-Request-Id': 'request_id' },
+              body: { username: 'user_name' }
+            )
+          end
+        end
+      end
+
+      describe '#inspect' do
+        it 'returns contents as string for to be readable for human' do
+          expect(instance.inspect)
+            .to eq '{:method=>:get, ' \
+                   ':uri=>"https://example.com/path/to/resource?key=value", ' \
+                   ':headers=>{:"X-Request-Id"=>"request_id"}, ' \
+                   ':body=>{:username=>"user_name"}}'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The API client allows lazy evaluation for request headers and body parameters.
For example, a time-limited token can be issued immediately before the request.

```rb
class ExampleApiClient < MyApiClient::Base
  def get_users
    get 'users', headers: headers, query: { key: 'value' }
  end

  private

  def headers
    lambda do
      new_access_token = issue_new_access_token!
      {
        'Content-Type': 'application/json;charset=UTF-8',
        'Authorization': "Bearer #{new_access_token}",
      }
    end
  end
end