### PR TITLE
Stop CI for the testing API test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,8 +293,9 @@ workflows:
             parameters:
               ruby_version: *ruby_version_enum
               rails_version: *rails_version_enum
-      - test_api:
-          ruby_version: "3.2" # Ruby on Jets requires Ruby 2.5, 2.7 or 3.2
+      # TODO: Update the version of Ruby on Jets or re-create the test API server with Ruby on Rails 8.0
+      # - test_api:
+      #     ruby_version: "3.2" # Ruby on Jets requires Ruby 2.5, 2.7 or 3.2
       - rubocop
       - yardoc
       - upload-coverage:


### PR DESCRIPTION
This gem has been tested with real API requests using a test API created by Ruby on Jets.
Unfortunately, I don't maintain the jets update for a long time, and then the testing API spec is broken.

---
My motivation for using Ruby on Jets is to keep server cost low by using AWS Lambda and API Gateway, etc.
On the other hand, even Ruby on Rails v8.0 has established a way to create a cheap server.
So, I may recreate the testing API with Ruby on Rails.