### PR TITLE
Allow to use instance writer in the logger

### DIFF
--- a/lib/my_api_client/base.rb
+++ b/lib/my_api_client/base.rb
@@ -8,7 +8,7 @@ module MyApiClient
     include MyApiClient::Exceptions
     include MyApiClient::Request
 
-    class_attribute :logger, instance_writer: false, default: ::Logger.new($stdout)
+    class_attribute :logger, default: ::Logger.new($stdout)
     class_attribute :error_handlers, instance_writer: false, default: []
 
     include MyApiClient::DefaultErrorHandlers

--- a/spec/lib/my_api_client/base_spec.rb
+++ b/spec/lib/my_api_client/base_spec.rb
@@ -19,9 +19,13 @@ RSpec.describe MyApiClient::Base do
 
   let(:instance) { mock_class.new }
 
-  describe '.logger=' do
+  describe '#logger=' do
+    let(:new_logger) { Logger.new($stdout) }
+
     it 'overrides the log output destination' do
-      expect(instance.logger).to be_a MyLoggerClass
+      expect(instance.logger).not_to eq(new_logger)
+      instance.logger = new_logger
+      expect(instance.logger).to eq(new_logger)
     end
   end
 end


### PR DESCRIPTION
Currently, MyApiClient does not allow you to use `instance_writer` in the logger. However, I found that there are cases where you want to override the logger.

For example, a large batch job that performs 1 million API requests outputs a huge amount of logs.
In my product, we log metrics to Datadog, and the huge amount of logs increases the cost.

If MyApiClient allows you to use `instance_writer`, then you will be able to change the logger to a different log level for the large batch job:

```rb
class ExampleApiClient < MyApiClient::Base
  self.logger = Rails.logger
end
```

```rb
api_client = ExampleApiClient.new
api_client.logger = build_thread_local_logger(Logger::WARN)

def build_thread_local_logger(level)
  loggers = Rails.logger.broadcasts.map do |rails_logger|
    Logger.new(rails_logger.instance_variable_get(:@logdev).dev).then do |new_logger|
      new_logger.level = level
      new_logger.formatter = rails_logger.formatter
      ActiveSupport::TaggedLogging.new(new_logger)
    end
  end
  ActiveSupport::BroadcastLogger.new(*loggers)
end
```