### PR TITLE
Stop stringifying the metadata left in the Bugsnag breadcrumb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :integrations, optional: true do
-  gem 'bugsnag', '>= 6.11.0'
+  gem 'bugsnag', '>= 6.19.0'
 end
 
 # Specify your gem's dependencies in my_api_client.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bugsnag (>= 6.11.0)
+  bugsnag (>= 6.19.0)
   bundler (>= 2.0)
   my_api_client!
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ end
 
 #### Bugsnag breadcrumbs
 
-If you are using [Bugsnag-Ruby v6.11.0](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.11.0) or later, the [breadcrumbs feature](https://docs.bugsnag.com/platforms/ruby/other/#logging-breadcrumbs) is supported automatically. When `MyApiClient::Error` occurs, `Bugsnag.leave_breadcrumb` is called internally, so you can inspect request and response details in the Bugsnag console.
+If you are using [Bugsnag-Ruby v6.19.0](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.19.0) or later, the [breadcrumbs feature](https://docs.bugsnag.com/platforms/ruby/other/#logging-breadcrumbs) is supported automatically. When `MyApiClient::Error` occurs, `Bugsnag.leave_breadcrumb` is called internally, so you can inspect request and response details in the Bugsnag console.
 
 ### Retry
 

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -9,7 +9,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'activesupport', '~> 7.2.0'
 
 group :integrations, optional: true do
-  gem 'bugsnag', '>= 6.11.0'
+  gem 'bugsnag', '>= 6.19.0'
 end
 
 gemspec

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -9,7 +9,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'activesupport', '~> 8.0.0'
 
 group :integrations, optional: true do
-  gem 'bugsnag', '>= 6.11.0'
+  gem 'bugsnag', '>= 6.19.0'
 end
 
 gemspec

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -9,7 +9,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'activesupport', '~> 8.1.0'
 
 group :integrations, optional: true do
-  gem 'bugsnag', '>= 6.11.0'
+  gem 'bugsnag', '>= 6.19.0'
 end
 
 gemspec

--- a/lib/my_api_client.rb
+++ b/lib/my_api_client.rb
@@ -33,7 +33,7 @@ require 'my_api_client/sleeper'
 # Loads gems for feature of integrations
 begin
   require 'bugsnag'
-  require 'my_api_client/integrations/bugsnag' if defined?(Bugsnag) && Bugsnag::VERSION >= '6.11.0'
+  require 'my_api_client/integrations/bugsnag' if defined?(Bugsnag) && Bugsnag::VERSION >= '6.19.0'
 rescue LoadError
   nil
 end

--- a/lib/my_api_client/integrations/bugsnag.rb
+++ b/lib/my_api_client/integrations/bugsnag.rb
@@ -11,7 +11,7 @@ module MyApiClient
 
       Bugsnag.leave_breadcrumb(
         "#{self.class.name} occurred",
-        metadata&.transform_values(&:inspect),
+        metadata,
         Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
       )
     end

--- a/spec/lib/my_api_client/integrations/bugsnag_spec.rb
+++ b/spec/lib/my_api_client/integrations/bugsnag_spec.rb
@@ -2,22 +2,17 @@
 
 if defined?(Bugsnag)
   RSpec.describe MyApiClient::Error do
-    let(:ruby34_or_later) { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4') }
-
     describe '#initialize' do
       context 'with params and error message' do
         let(:params) { instance_double(MyApiClient::Params::Params, metadata:) }
         let(:metadata) { { a: 1, b: { c: 2, d: 3 } } }
-        let(:expected_metadata) do
-          ruby34_or_later ? { a: '1', b: '{c: 2, d: 3}' } : { a: '1', b: '{:c=>2, :d=>3}' }
-        end
 
         it 'calls Bugsnag.leave_breadcrumb with metadata' do
           allow(Bugsnag).to receive(:leave_breadcrumb)
           described_class.new(params, 'error message')
           expect(Bugsnag).to have_received(:leave_breadcrumb).with(
             'MyApiClient::Error occurred',
-            expected_metadata,
+            metadata,
             Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
           )
         end


### PR DESCRIPTION
# Why

`MyApiClient::Error#initialize` calls `Bugsnag.leave_breadcrumb` passing `metadata&.transform_values(&:inspect)` as its metadata. This `.transform_values(&:inspect)` was introduced in [ef6310d](https://github.com/ryz310/my_api_client/commit/ef6310d) (2019) as a workaround for a limitation in `bugsnag-ruby` that has since been removed — and is now actively harmful.

## The original problem: `bugsnag-ruby` v6.11.0 silently dropped `Hash`/`Array` from breadcrumb metadata

`bugsnag-ruby` [v6.11.0](https://github.com/bugsnag/bugsnag-ruby/blob/v6.30.0/CHANGELOG.md#6110-17-january-2019) (2019-01-17, [PR #525](https://github.com/bugsnag/bugsnag-ruby/pull/525)) introduced the breadcrumb feature along with a strict type validator, `Bugsnag::Breadcrumbs::Validator#valid_meta_data_type?`, which silently dropped any metadata value that was not a primitive type:

```ruby
# bugsnag-ruby v6.11.0 through v6.18.0
def valid_meta_data_type?(value)
  value.nil? || value.is_a?(String) || value.is_a?(Symbol) ||
    value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
end

breadcrumb.meta_data = breadcrumb.meta_data.select do |k, v|
  if valid_meta_data_type?(v)
    true
  else
    @configuration.debug("Breadcrumb #{breadcrumb.name} meta_data #{k}:#{v.class} has been dropped for having an invalid data type")
    false
  end
end
```

`Hash`/`Array` values such as `response_body: { errors: [...] }` failed this check and were silently discarded, leaving only a single debug log line. Converting every value to a `String` via `.transform_values(&:inspect)` ensured they passed the validator and reached Bugsnag.

## The restriction was removed in `bugsnag-ruby` v6.19.0

This limitation was removed in [PR #648 "Remove breadcrumb metadata validation"](https://github.com/bugsnag/bugsnag-ruby/pull/648) (merged 2020-12-22, merge commit [`1828f9bc`](https://github.com/bugsnag/bugsnag-ruby/commit/1828f9bc9fa82786135afba104cbcf11a821e0d2)), released as [`v6.19.0`](https://github.com/bugsnag/bugsnag-ruby/blob/v6.30.0/CHANGELOG.md#6190-6-january-2021) (2021-01-06):

> We currently only allow a small subset of types in breadcrumb metadata. This is a holdover from an old constraint and is no longer necessary
>
> _(CHANGELOG, `v6.19.0`)_ Breadcrumb metadata can now contain any type | [#648](https://github.com/bugsnag/bugsnag-ruby/pull/648)

## The workaround now breaks Bugsnag's redaction

Now that `bugsnag-ruby >= 6.19.0` accepts `Hash`/`Array` natively and traverses them recursively, keeping `.transform_values(&:inspect)` only has the harmful side effect of disabling Bugsnag's built-in redaction.

`Bugsnag::Configuration#redacted_keys` and `#meta_data_filters` work by matching **key names** as `Bugsnag::Cleaner` recursively traverses the metadata structure. Once metadata like this:

```ruby
{ response_body: { errors: [{ option: { email: "hoge@example.com" } }] } }
```

is flattened by `.inspect` into a single string:

```ruby
{ response_body: "{:errors=>[{:option=>{:email=>\"hoge@example.com\"}}]}" }
```

the `email` key no longer exists as a key — it is buried inside a string — so `redacted_keys` cannot match it. As a result, PII in API response bodies (emails, phone numbers, etc.) ends up displayed in plain text on the Bugsnag dashboard, regardless of how `redacted_keys` is configured.

## Why the minimum supported `bugsnag-ruby` version must be raised

Passing raw metadata (without `.transform_values(&:inspect)`) is only safe with `bugsnag-ruby >= 6.19.0`. On `<= 6.18.0`, `Hash`/`Array` values would be silently dropped from the breadcrumb — strictly worse than the current behaviour, where at least the `.inspect`-ed strings arrive at Bugsnag.

This PR raises the floor from `>= 6.11.0` to `>= 6.19.0`.

# How

- Stop stringifying the metadata: pass `metadata` to `Bugsnag.leave_breadcrumb` as-is instead of `metadata&.transform_values(&:inspect)`.
- Raise the minimum supported `bugsnag-ruby` version from `>= 6.11.0` to `>= 6.19.0`.

Note: this is a breaking change for anyone relying on breadcrumb metadata values being strings — they will now be the original `Hash`/`Array`/`Numeric`/etc. types.

# Verification

## How to Verification

Rather than hand-building metadata, the script below triggers a real `MyApiClient::Error` from a stubbed `422` API response and lets the patched integration build the breadcrumb and notify Bugsnag on its own, so the cleaned/redacted result can be inspected on the dashboard.

**Verification environment**

- Ruby 4.0.5 (Rails 8.1.3)
- bugsnag 6.30.0

```ruby
require 'webmock'
include WebMock::API
WebMock.enable!

require 'my_api_client'

Bugsnag.configure do |config|
  config.api_key = '' # use a real project's API key
  config.notify_release_stages = %w[development]
  config.redacted_keys << /email/i # redacted_keys requires bugsnag-ruby >= 6.24.0
end

class VerificationApiClient < MyApiClient::Base
  endpoint 'https://example.com/v1'

  def get_user
    get 'users/1'
  end
end

stub_request(:get, 'https://example.com/v1/users/1').to_return(
  status: 422,
  headers: { 'Content-Type' => 'application/json' },
  body: {
    ok: false,
    retryable: true,
    errors: [{ code: 422, option: { email: 'hoge@example.com' } }]
  }.to_json
)

api_client = VerificationApiClient.new

error = nil

begin
  api_client.get_user
rescue MyApiClient::Error => e
  error = e
end

WebMock.disable!
Bugsnag.notify(error)
```

## Result

- [x] `metaData.response_body.errors[0].option.email` shows as `"[FILTERED]"`, with the surrounding `errors[0].option` structure intact
- [x] `metaData.response_body.ok` / `.retryable` show as `false` / `true` (booleans), not the strings `"false"`/`"true"`
- [x] `metaData.response_status` shows as `422` (number)
- [x] `metaData.request_line` shows as `"GET https://example.com/v1/users/1"`, and `metaData.duration` shows as a float (e.g. `0.0042`)

**After this change**

<img width="570" height="560" alt="result" src="https://github.com/user-attachments/assets/d6f0c23f-2d7d-4bf2-8b68-267c61a961b2" />

**Before this change**

<img width="953" height="261" alt="master" src="https://github.com/user-attachments/assets/434f39f9-ab2d-4ffe-9475-fefcd441949d" />