### PR TITLE
ci: switch release workflow to RubyGems Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -26,28 +27,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0'
-          bundler-cache: false
+          bundler-cache: true
 
-      - name: Install Bundler 2.x
-        run: gem install bundler -v "~> 2.0"
-
-      - name: Bundle install
-        run: bundle install
-
-      - name: Configure Git user
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Create RubyGems credentials
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: |
-          mkdir -p ~/.gem
-          printf -- "---\n:rubygems_api_key: %s\n" "${RUBYGEMS_API_KEY}" > ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
-
-      - name: Release gem
-        run: |
-          git push --set-upstream origin "${GITHUB_REF_NAME}" || true
-          bundle exec rake release --trace
+      - name: Release gem via Trusted Publishing
+        uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ coding agents (see `AGENTS.md`), which is the primary reason for the major versi
 - [#1180](https://github.com/ryz310/my_api_client/pull/1180) docs: complete README WIP sections and refine wording ([@ryz310](https://github.com/ryz310))
 - [#1181](https://github.com/ryz310/my_api_client/pull/1181) Consolidate README docs and remove README.jp.md ([@ryz310](https://github.com/ryz310))
 - [#1187](https://github.com/ryz310/my_api_client/pull/1187) Split Dependabot auto-merge logic by ecosystem ([@ryz310](https://github.com/ryz310))
+- [#1308](https://github.com/ryz310/my_api_client/pull/1308) Switch release workflow to RubyGems Trusted Publishing ([@ryz310](https://github.com/ryz310))
 
 ## v1.3.1 (Jun 10, 2025)
 


### PR DESCRIPTION
## Purpose of this change

API キー方式の `gem push` では、アカウントの MFA（`rubygems_mfa_required = true` + WebAuthn/OTP）により CI から非対話で公開できず、リリースが以下のように失敗・停止していました。

- API キーが `401 Invalid credentials`
- `gem push` が OTP 入力待ちで stdin をブロックし約5分後にタイムアウト
- WebAuthn 検証のローカルコールバック待ちで `execution expired`

これらは鍵/OTP/WebAuthn を CI で対話的に扱えないことが根本原因のため、鍵レスかつ OTP 不要で公開できる **RubyGems Trusted Publishing (OIDC)** に切り替えます。

## What changed

- 公式アクション `rubygems/release-gem@v1` を採用（OIDC 認証設定 → `bundle exec rake release`（ビルド・git タグ push・RubyGems push・伝播待ち）を一括実行）
- `permissions` に `id-token: write` を追加（OIDC トークン発行に必須）
- `RUBYGEMS_API_KEY` シークレットと `~/.gem/credentials` 作成ステップを削除
- 手動の Git ユーザー設定 / `git push --set-upstream` / `rake release` 実行ステップをアクションへ集約
- `bundler-cache: true` に変更

## Required setup before merge/release

- RubyGems.org 側で Trusted Publisher を登録する必要があります（未登録だと OIDC 認証が通りません）。
  - Repository owner: `ryz310`
  - Repository name: `my_api_client`
  - Workflow filename: `release.yml`
- 不要になった `secrets.RUBYGEMS_API_KEY` は他で未使用なら削除可能です。

## Note

前回の失敗時に `v2.0.0` タグと commit は origin に push 済みです。マージ後に `release` ブランチへ反映して再実行する際は、`rake release` が再度タグ付けを試みるため、必要に応じて既存タグを削除してから実行してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
