### PR TITLE
ci: always auto-merge verification app dependabot PRs (except rails major)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,8 +23,56 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge for bundler patch/minor updates (rails_app or direct development)
-        if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor') && (contains(github.event.pull_request.head.ref, '/rails_app/') || steps.metadata.outputs.dependency-type == 'direct:development') }}
+      - name: Validate bundler update safety
+        id: guard
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' }}
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          DEPENDENCY_NAME: ${{ steps.metadata.outputs.dependency-name }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+
+          safe=false
+
+          deps="$DEPENDENCY_NAMES"
+          if [[ -z "$deps" ]]; then
+            deps="$DEPENDENCY_NAME"
+          fi
+
+          rails_involved=false
+          while IFS= read -r dep; do
+            dep="$(echo "$dep" | xargs)"
+            [[ -z "$dep" ]] && continue
+            if [[ "$dep" == "rails" ]]; then
+              rails_involved=true
+            fi
+          done < <(echo "$deps" | tr ',' '\n')
+
+          if [[ "$HEAD_REF" == *"/rails_app/"* ]]; then
+            # Verification Rails apps: always auto-merge, except a major bump of the rails gem itself.
+            if [[ "$UPDATE_TYPE" == "version-update:semver-major" && "$rails_involved" == "true" ]]; then
+              echo "Skip auto-merge: major update of the rails gem in a rails_app verification app."
+              safe=false
+            else
+              safe=true
+            fi
+          elif [[ "$HEAD_REF" == *"/my_api/"* ]]; then
+            # Verification API app: always auto-merge regardless of update type.
+            safe=true
+          elif [[ ("$UPDATE_TYPE" == "version-update:semver-patch" || "$UPDATE_TYPE" == "version-update:semver-minor") && "$DEPENDENCY_TYPE" == "direct:development" ]]; then
+            # The gem itself (root Gemfile): only direct development patch/minor updates.
+            safe=true
+          else
+            echo "Skip auto-merge: gem update does not match auto-merge policy ($UPDATE_TYPE, $DEPENDENCY_TYPE)."
+          fi
+
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge for safe bundler updates
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' && steps.guard.outputs.safe == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/docs/runbooks/dependabot_pr_auto_merge.md
+++ b/docs/runbooks/dependabot_pr_auto_merge.md
@@ -24,6 +24,15 @@ sed -n '1,260p' AGENTS.md
 ## Auto-merge workflow policy
 - Keep `package-ecosystem` decisions separated in `.github/workflows/dependabot-auto-merge.yml`.
 - Apply independent conditions for each ecosystem to avoid cross-ecosystem condition mixing.
+- For `bundler` ecosystem auto-merge:
+  - Verification apps (`rails_app/*` and `my_api`) are always auto-merged regardless of update type
+    (including major), because bundle update failures there do not affect the published gem and are
+    gated by CI/branch protection.
+  - Exception: a major update of the `rails` gem itself under `rails_app/*` is NOT auto-merged,
+    because a Rails major bump is treated as an explicit support-matrix decision that requires manual
+    review. Other gems' major updates under `rails_app/*` are still auto-merged.
+  - The gem itself (root `Gemfile`) is auto-merged only for `direct:development` dependencies on
+    non-major updates (patch/minor).
 - For `github-actions` ecosystem auto-merge, require all of the following:
   - GitHub official actions only (`actions/*` or `github/*`)
   - non-major updates only (patch/minor)


### PR DESCRIPTION
## Purpose of this change

Dependabot PRs under the verification apps (rails_app/* and my_api) only bump
dependencies of test/verification Rails apps, not the published gem. A failed
bundle update there is caught by CI and does not put the gem at risk, so keeping
them in the manual-review queue adds review load with little benefit. This change
lets those PRs be auto-merged regardless of update type, while still protecting
the gem itself and the one case that is a real decision: a Rails major bump.

## What changed

- Rewrote the bundler job in .github/workflows/dependabot-auto-merge.yml as a
  shell guard (same pattern as the github-actions job) so a specific dependency
  name (rails) can be matched precisely without false matches like
  rails-html-sanitizer.
- New bundler auto-merge policy:
  - rails_app/* : always auto-merge (including major), EXCEPT a major bump of the
    rails gem itself, which stays manual (explicit support-matrix decision).
  - my_api : always auto-merge regardless of update type.
  - root Gemfile (the gem itself) : unchanged, only direct:development patch/minor.
- Documented the bundler policy and the rails-major exception in
  docs/runbooks/dependabot_pr_auto_merge.md.

## Notes

- Actual merge is still gated by branch protection and required checks; this only
  controls whether auto-merge is enabled.
- Guard logic was simulated across the main scenarios (rails major/patch, other
  gem major, rails-html-sanitizer, my_api rails major, root dev/prod) and behaved
  as expected.
