### PR TITLE
docs: require English for PR titles and descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@
 ## Pull Request Description Rule
 
 - In PR descriptions, include a `Purpose of this change` section that explains why the change is needed, not only what changed.
+- Write PR titles and descriptions in English to keep them consistent across the repository.
 
 ## GitHub CLI Body Safety
 


### PR DESCRIPTION
## Purpose of this change

PR titles and descriptions in this repository have been written inconsistently, some in Japanese and some in English. Standardizing on English keeps the project history consistent and readable for all contributors, and gives agents a single, unambiguous convention to follow.

## What changed

- Add a rule to the `Pull Request Description Rule` section of AGENTS.md: write PR titles and descriptions in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
