### PR TITLE
docs: use tool-specific branch prefix in branch creation rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,15 @@
 - Always create a new branch from `master`.
 - Before creating a branch, update local `master` with the latest commits from `origin`.
 - After updating local `master`, reload and re-read `AGENTS.md` before starting any new task.
-- Example flow:
+- Use a branch prefix that matches the agent tool in use:
+  - Codex: `codex/<new-branch-name>`
+  - Claude Code: `claude/<new-branch-name>`
+- Example flow (replace `<prefix>` with the prefix for your tool):
   1. `git checkout master`
   2. `git fetch origin`
   3. `git pull --ff-only origin master`
   4. Re-open `AGENTS.md` and confirm instructions
-  5. `git checkout -b codex/<new-branch-name>`
+  5. `git checkout -b <prefix>/<new-branch-name>`
 
 ## Development Version Policy
 


### PR DESCRIPTION
## Purpose of this change

The branch creation rule hard-coded the `codex/` prefix, but this repository's agent instructions are shared across tools (Codex and Claude Code). When working with Claude Code, branches should be created with a `claude/` prefix so the branch name reflects which agent produced the work. This makes branch provenance clear at a glance and avoids mislabeling Claude Code branches as Codex branches.

## What changed

- Add a tool-specific branch prefix rule to the Branch Creation Rule section in `AGENTS.md`:
  - Codex: `codex/<new-branch-name>`
  - Claude Code: `claude/<new-branch-name>`
- Update the example flow to use a `<prefix>` placeholder instead of the fixed `codex/` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
