### PR TITLE
ci: scope dependabot auto-merge permissions per job

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,14 +7,15 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   enable-automerge-bundler:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Fetch Dependabot metadata
@@ -81,6 +82,9 @@ jobs:
   enable-automerge-github-actions:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Purpose of this change

Qlty (zizmor) reported an `excessive-permissions` (overly broad permissions) finding on `.github/workflows/dependabot-auto-merge.yml`. The workflow declared `contents: write` and `pull-requests: write` at the top level, so those write permissions were inherited by every job in the workflow. This violates the principle of least privilege and widens the blast radius if any step is compromised, which is especially sensitive here because the workflow runs on `pull_request_target`.

## What changed

- Set the top-level `permissions` to `{}` (no permissions granted by default).
- Grant `contents: write` and `pull-requests: write` only to the two jobs that actually enable auto-merge (`enable-automerge-bundler` and `enable-automerge-github-actions`), which invoke `gh pr merge --auto --merge`.

This keeps the auto-merge behavior unchanged while scoping write permissions to the jobs that require them.

## Verification

- Validated the workflow YAML parses correctly.
- `zizmor` could not be run locally (binary not installed and no `uvx`/`pipx` available), so the fix follows zizmor's recommended pattern: minimal top-level permissions with write permissions scoped per job.
