### PR TITLE
ci: use non-spoofable actor check for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   enable-automerge-bundler:
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -79,7 +79,7 @@ jobs:
         run: gh pr merge --repo "$GITHUB_REPOSITORY" --auto --merge "$PR_NUMBER"
 
   enable-automerge-github-actions:
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Purpose of this change

The `dependabot-auto-merge.yml` workflow runs on `pull_request_target` with
`contents: write` and `pull-requests: write` permissions. Both jobs gated the
run with `github.actor == 'dependabot[bot]'`.

In the `pull_request_target` context, `github.actor` reflects the user that
last triggered the event and can be spoofed, so this check is not a reliable
way to confirm the PR actually comes from Dependabot. This was flagged by
zizmor's `bot-conditions` rule (spoofable bot actor check) via qlty.

## What changed

- Replace `github.actor == 'dependabot[bot]'` with the non-spoofable
  `github.event.pull_request.user.login == 'dependabot[bot]'` in both jobs
  (`enable-automerge-bundler` and `enable-automerge-github-actions`).

This references the PR author directly, which cannot be spoofed, and is the
fix recommended by zizmor.
