### PR TITLE
ci: use pull_request trigger for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Purpose of this change

zizmor's dangerous-triggers rule (High) flags the use of pull_request_target in the Dependabot auto-merge workflow. This trigger runs with write permissions and repository secrets while being able to be tricked into using untrusted PR content, so it is considered fundamentally insecure.

## What changed

- Switch the trigger of the Dependabot auto-merge workflow from pull_request_target to pull_request.

## Why this is safe and keeps working

- The workflow never checks out or executes PR code. It only runs dependabot/fetch-metadata, gh api, and gh pr merge.
- The only reason pull_request_target was used was to obtain write access, but for Dependabot-triggered pull_request events GitHub honors the workflow permissions block, so the job-level write permissions are still granted.
- This matches GitHub's official recommended pattern for Dependabot auto-merge.
- The non-spoofable author guard (github.event.pull_request.user.login == 'dependabot[bot]') and the per-job least-privilege permissions remain unchanged.
