### PR TITLE
ci: disable credential persistence on checkout (zizmor artipacked)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             without: integrations
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -99,6 +101,8 @@ jobs:
         working-directory: rails_app/rails_${{ matrix.rails_version }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -142,6 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Build and start my_api
         run: docker compose up -d --build my_api
@@ -185,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Build and start my_api
         run: docker compose up -d --build my_api
@@ -221,6 +229,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -241,6 +251,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
@@ -280,6 +292,8 @@ jobs:
       QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # rubygems/release-gem runs `rake release`, which pushes the git tag,
+      # so the checkout credentials must persist for this release job.
+      - uses: actions/checkout@v7 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}

--- a/.github/workflows/rubocop_challenge.yml
+++ b/.github/workflows/rubocop_challenge.yml
@@ -18,7 +18,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # rubocop_challenger pushes a branch and opens a pull request,
+      # so the checkout credentials must persist for the git push.
+      - uses: actions/checkout@v7 # zizmor: ignore[artipacked]
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0


### PR DESCRIPTION
## Purpose of this change

Qlty (zizmor) reports the **artipacked** rule (credential persistence through GitHub Actions artifacts) across our workflows. By default, `actions/checkout` persists the repository credentials in the checkout, which can be leaked if the workspace is later uploaded as an artifact. Disabling credential persistence on checkout steps that do not need to push removes this attack surface.

## What changed

- `.github/workflows/ci.yml`: add `persist-credentials: false` to all 7 checkout steps. None of these jobs push to the repository (they only build/test/upload coverage artifacts), so disabling persistence is safe and closes the findings.
- `.github/workflows/release.yml` and `.github/workflows/rubocop_challenge.yml`: these jobs legitimately require the persisted git credentials:
  - `release.yml` runs `rubygems/release-gem` (`rake release`), which pushes the git tag.
  - `rubocop_challenge.yml` runs `rubocop_challenger`, which pushes a branch and opens a pull request.
  
  For these two, credential persistence is intentional, so they carry a documented `# zizmor: ignore[artipacked]` comment explaining why.

## Verification

Ran zizmor locally (`--offline`) against `.github/workflows/`:

- Active `artipacked` findings: **0** (7 resolved via `persist-credentials: false`, 2 intentionally ignored with justification).

No `.rb` files were changed, so RuboCop validation is not required per the project Validation Rule.
