### PR TITLE
fix(ci): disable bundler cache in release workflow to prevent cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,16 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Set up Ruby
+        # bundler-cache is disabled to avoid a cache-poisoning attack surface:
+        # this workflow publishes a gem, so a poisoned dependency cache could
+        # contaminate the released artifact.
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '4.0'
-          bundler-cache: true
+          bundler-cache: false
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Release gem via Trusted Publishing
         uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Purpose of this change

zizmor (zizmor/cache-poisoning, severity: High) flagged the release
workflow as vulnerable to a cache-poisoning attack. Because this
workflow publishes a gem via Trusted Publishing, a poisoned dependency
cache could be restored during the release job and contaminate the
released artifact. Removing the dependency cache from this
security-sensitive publishing workflow eliminates that attack surface.

## What changed

- Disable the bundler cache in the Release workflow by setting
  bundler-cache to false in the ruby/setup-ruby step.
- Install dependencies in a dedicated "Install dependencies" step
  (bundle install) instead of relying on the cached install.
- Add an inline comment explaining why caching is intentionally
  disabled here.

## Notes

- Only .github/workflows/release.yml is changed; no Ruby source files
  are affected, so RuboCop validation is not required.
- The cache is only used to speed up dependency installation. Disabling
  it slightly increases release job runtime but has no functional impact
  on the published gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
