### PR TITLE
fix(ci): pin rubygems/release-gem to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
         run: bundle install
 
       - name: Release gem via Trusted Publishing
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,8 @@
 ## GitHub Actions Pinning Policy
 
 - Pin third-party actions to a full commit SHA with a version comment (e.g. `uses: ruby/setup-ruby@<sha> # v1.321.0`) to satisfy zizmor `unpinned-uses`.
-- GitHub-owned actions (`actions/*`, `github/*`, `rubygems/*`, `dependabot/*`) may stay ref-pinned; Dependabot (`github-actions`) keeps the pins and version comments updated.
+- GitHub-owned actions (`actions/*`, `github/*`, `dependabot/*`) may stay ref-pinned; Dependabot (`github-actions`) keeps the pins and version comments updated.
+- Third-party actions outside those GitHub-owned orgs (e.g. `ruby/*`, `rubygems/*`) must be SHA-pinned; zizmor `unpinned-uses` flags them otherwise. Dependabot still keeps the SHA pins and version comments updated.
 
 ## Runbook
 


### PR DESCRIPTION
## Summary

Pin `rubygems/release-gem` in the release workflow to a full commit SHA to resolve the zizmor `unpinned-uses` (High) finding reported by Qlty.

- `.github/workflows/release.yml`: change `rubygems/release-gem@v1` to `rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0`, matching the SHA + version comment style already used for `ruby/setup-ruby`.
- `AGENTS.md`: correct the GitHub Actions Pinning Policy. `rubygems/*` is not a GitHub-owned org, so it was moved out of the ref-pin allowlist. Third-party actions outside `actions/*`, `github/*`, and `dependabot/*` must be SHA-pinned. Dependabot (`github-actions`) still keeps the SHA pins and version comments updated.

## Purpose of this change

`@v1` resolved to the moving `v1` branch, so a compromise or force-push upstream could alter the action executed by the release job that publishes the gem via Trusted Publishing. Pinning to the immutable commit SHA of the `v1.4.0` release removes this supply-chain risk and clears the zizmor `unpinned-uses` finding. The previous AGENTS.md policy incorrectly treated `rubygems/*` as GitHub-owned and exempt from SHA pinning, which conflicted with zizmor; the policy is corrected to prevent the same gap from reappearing.
